### PR TITLE
Keep stats at 0 if nothing passed

### DIFF
--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -169,13 +169,17 @@ module.exports = function(grunt) {
           if(element.failed > 0) {
             return feature.failed++;
           }
-          feature.passed++;
+          if (element.passed > 0) {
+            return feature.passed++;
+          }
         });
 
         if(feature.failed > 0) {
           return suite.failed++;
         }
-        suite.passed++;
+        if(feature.passed > 0) {
+          return suite.passed++;
+        }
       });
 
       suite.features = features;


### PR DESCRIPTION
Was getting features shown as successful if though none of the scenarios had passed.

With this change the feature will not be reported as successful unless at least 1 scenario is implemented and passed.
