### PR TITLE
Added support for multiple CucumberJS --tags flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Default: `''`
 passes the value as ```--steps``` parameter to cucumber.
 
 #### options.tags
-Type: `String`
+Type: `String|Array`
 Default: `''`
 
-passes the value as ```--tags``` parameter to cucumber.
+Passes the value as ```--tags``` parameter to cucumber. If an array, each item is passed as a separate ```--tags``` parameter.
 
 #### options.theme
 Type: `String`

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -44,7 +44,13 @@ module.exports = function(grunt) {
     }
 
     if (options.tags) {
-      commands.push('-t', options.tags);
+      if (options.tags instanceof Array) {
+        options.tags.forEach(function(element, index, array) {
+          commands.push('-t', element);
+        });
+      } else {
+        commands.push('-t', options.tags);
+      }
     }
 
     if (options.format === 'html') {


### PR DESCRIPTION
CucumberJS supports multiple --tags flags, which modifies the inclusion/exclusion rules of features. This PR enables grunt-cucumberjs to be configured with an array of tags. https://github.com/cucumber/cucumber-js/blob/master/lib/cucumber/cli.js#L51
