### PR TITLE
added require option and also ability to imbed screenshots in reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ this.After(function (scenario, callback) {
 ```
 Below are some sample HTML reports with screenshots (note that javascript to collapse/expand a screenshots doesn't appear to respond in htmlpreview site below, but they should work fine on locally generated reports,
 
-[Bootstrap Theme Reports][3]
-[Simple Theme Reports][4]
-[Foundation Theme Reports][5]
+*[Bootstrap Theme Reports][3]
+*[Simple Theme Reports][4]
+*[Foundation Theme Reports][5]
 
 [1]: https://code.google.com/p/selenium/wiki/WebDriverJs "WebDriverJS"
 [2]: https://github.com/cucumber/cucumber-js "cucumber-js"

--- a/README.md
+++ b/README.md
@@ -118,3 +118,31 @@ Default: `'false'`
 Available: `['true', 'false']`
 
 A flag to turn console log on or off
+
+### Attaching Screenshots to grunt-cucumberjs HTML report
+
+If you are using [WebDriverJS][1] (or related framework) along with [cucumber-js][2] for browser automation, you can attach screenshots to grunt-cucumberjs HTML report. Typically screenshots are taken after a test failure to help debug what went wrong when analyzing results, for example
+
+```javascript
+this.After(function (scenario, callback) {
+        if(scenario.isFailed()){
+            driver.takeScreenshot().then(function (buffer) {
+                scenario.attach(new Buffer(buffer, 'base64').toString('binary'), 'image/png');
+                 driver.quit().then(function () {
+                                callback();
+                 });
+            });
+        }
+});
+```
+Below are some sample HTML reports with screenshots (note that javascript to collapse/expand a screenshots doesn't appear to respond in htmlpreview site below, but they should work fine on locally generated reports,
+
+[Bootstrap Theme Reports][3]
+[Simple Theme Reports][4]
+[Foundation Theme Reports][5]
+
+[1]: https://code.google.com/p/selenium/wiki/WebDriverJs "WebDriverJS"
+[2]: https://github.com/cucumber/cucumber-js "cucumber-js"
+[3]: http://htmlpreview.github.io/?https://github.com/nikulkarni/grunt-cucumberjs/blob/screenshot/report/cucumber_report_bootstrap.html "Bootstrap Theme Reports"
+[4]: http://htmlpreview.github.io/?https://github.com/nikulkarni/grunt-cucumberjs/blob/screenshot/report/cucumber_report_simple.html "Simple Theme Reports"
+[5]: http://htmlpreview.github.io/?https://github.com/nikulkarni/grunt-cucumberjs/blob/screenshot/report/cucumber_report_foundation.html "Foundation Theme Reports"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ cucumberjs: {
 #runs all features specified in task
 $ grunt cucumberjs
 
+#provide step_definitions and hooks if they are NOT in default location of ```features/step_definitions```
+$ grunt cucumberjs --require=test/functional/step_definitions/
+
 #you can override options via the cli
 $ grunt cucumberjs --features=features/myFeature.feature --format=pretty
 ```

--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ this.After(function (scenario, callback) {
 ```
 Below are some sample HTML reports with screenshots (note that javascript to collapse/expand a screenshots doesn't appear to respond in htmlpreview site below, but they should work fine on locally generated reports,
 
-*[Bootstrap Theme Reports][3]
-*[Simple Theme Reports][4]
-*[Foundation Theme Reports][5]
+1. [Bootstrap Theme Reports][3]
+2. [Simple Theme Reports][4]
+3. [Foundation Theme Reports][5]
 
 [1]: https://code.google.com/p/selenium/wiki/WebDriverJs "WebDriverJS"
 [2]: https://github.com/cucumber/cucumber-js "cucumber-js"

--- a/package.json
+++ b/package.json
@@ -1,28 +1,17 @@
 {
   "name": "grunt-cucumberjs",
   "description": "Generates documentation from Cucumber features",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "homepage": "https://github.com/mavdi/grunt-cucumberjs",
-  "author": {
-    "name": "Mehdi Avdi",
-    "email": "mehdi.avdi@gmail.com"
-  },
+  "author": "Mehdi Avdi <mehdi.avdi@gmail.com>",
   "repository": {
     "type": "git",
     "url": "git://github.com/mavdi/grunt-cucumberjs.git"
   },
-
-  "contributors" : [
-    { "name" : "Andrew Keig",
-     "email" : "andrew.keig@gmail.com",
-     "url" : "https://github.com/AndrewKeig"
-    },
-    { "name" : "Jozz Hart",
-     "email" : "me@jozzhart.com",
-     "url" : "http://jozzhart.com"
-    }
+  "contributors": [
+    "Andrew Keig <andrew.keig@gmail.com> (https://github.com/AndrewKeig)",
+    "Jozz Hart <me@jozzhart.com> (http://jozzhart.com)"
   ],
-
   "bugs": {
     "url": "https://github.com/mavdi/grunt-cucumberjs/issues"
   },
@@ -56,5 +45,6 @@
     "handlebars": "~1.0.12",
     "underscore": "~1.5.2",
     "commondir": "~0.0.1"
-  }
+  },
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -3,15 +3,26 @@
   "description": "Generates documentation from Cucumber features",
   "version": "0.5.1",
   "homepage": "https://github.com/mavdi/grunt-cucumberjs",
-  "author": "Mehdi Avdi <mehdi.avdi@gmail.com>",
+  "author": {
+    "name": "Mehdi Avdi",
+    "email": "mehdi.avdi@gmail.com"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/mavdi/grunt-cucumberjs.git"
   },
-  "contributors": [
-    "Andrew Keig <andrew.keig@gmail.com> (https://github.com/AndrewKeig)",
-    "Jozz Hart <me@jozzhart.com> (http://jozzhart.com)"
+
+  "contributors" : [
+    { "name" : "Andrew Keig",
+     "email" : "andrew.keig@gmail.com",
+     "url" : "https://github.com/AndrewKeig"
+    },
+    { "name" : "Jozz Hart",
+     "email" : "me@jozzhart.com",
+     "url" : "http://jozzhart.com"
+    }
   ],
+
   "bugs": {
     "url": "https://github.com/mavdi/grunt-cucumberjs/issues"
   },
@@ -45,6 +56,5 @@
     "handlebars": "~1.0.12",
     "underscore": "~1.5.2",
     "commondir": "~0.0.1"
-  },
-  "license": "MIT"
+  }
 }

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -178,11 +178,11 @@ module.exports = function(grunt) {
           element.skipped = 0;
 
           element.steps.forEach(function(step) {
-            if (step.result.embeddings !== undefined) {
+            if (step.embeddings !== undefined) {
               if(!fs.existsSync(scrshotDir)){
                 fs.mkdirSync(scrshotDir);
               }
-              var stepData = step.result.embeddings[0],
+              var stepData = step.embeddings[0],
                   name= step.name && step.name.split(' ').join('_')|| step.keyword.trim(),
                   name = name + Math.round(Math.random() * 10000) + '.png', //randomize the file name
                   filename = scrshotDir + name;

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -61,6 +61,10 @@ module.exports = function(grunt) {
       commands.push('-f', options.format);
     }
 
+    if(grunt.option('require')) {
+      commands.push('--require', grunt.option('require'));
+    }
+
     if (grunt.option('features')) {
       commands.push(grunt.option('features'));
     } else {

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -186,7 +186,11 @@ module.exports = function(grunt) {
                   name= step.name && step.name.split(' ').join('_')|| step.keyword.trim(),
                   name = name + Math.round(Math.random() * 10000) + '.png', //randomize the file name
                   filename = scrshotDir + name;
-              fs.writeFileSync(filename, new Buffer(stepData.data, 'base64'));
+              fs.writeFile(filename, new Buffer(stepData.data, 'base64'), function(err) {
+                  if(err){
+                    console.error('Error saving screenshot '+filename); //asynchronously save screenshot
+                  }
+              });
               step.image = 'screenshot/'+ name;
             }
             if(!step.result) {

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -173,6 +173,13 @@ module.exports = function(grunt) {
           element.skipped = 0;
 
           element.steps.forEach(function(step) {
+            if (step.result.embeddings !== undefined) {
+              var stepData = step.result.embeddings[0],
+                  name= step.name && step.name.split(' ').join('_')|| step.keyword.trim();
+              name = name + Math.round(Math.random() * 10000) + '.png'; //randomize the file name
+              fs.writeFileSync(name, new Buffer(stepData.data, 'base64'));
+              step.image = name;
+            }
             if(!step.result) {
               return 0;
             }

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -7,7 +7,7 @@
 */
 
 'use strict';
-
+var fs = require('fs');
 module.exports = function(grunt) {
 
   var version = grunt.file.readJSON('./package.json').version;
@@ -156,7 +156,12 @@ module.exports = function(grunt) {
     var setStats = function(suite) {
       var features = suite.features;
       var rootDir = commondir(_.pluck(features, 'uri'));
-
+      var scrshotDir;
+      if(options.output.lastIndexOf('/')>-1) {
+        scrshotDir  = options.output.substring(0, options.output.lastIndexOf('/')) + '/screenshot/';
+      } else {
+        scrshotDir = 'screenshot/';
+      }
       features.forEach(function(feature) {
         feature.passed = 0;
         feature.failed = 0;
@@ -174,11 +179,15 @@ module.exports = function(grunt) {
 
           element.steps.forEach(function(step) {
             if (step.result.embeddings !== undefined) {
+              if(!fs.existsSync(scrshotDir)){
+                fs.mkdirSync(scrshotDir);
+              }
               var stepData = step.result.embeddings[0],
-                  name= step.name && step.name.split(' ').join('_')|| step.keyword.trim();
-              name = name + Math.round(Math.random() * 10000) + '.png'; //randomize the file name
-              fs.writeFileSync(name, new Buffer(stepData.data, 'base64'));
-              step.image = name;
+                  name= step.name && step.name.split(' ').join('_')|| step.keyword.trim(),
+                  name = name + Math.round(Math.random() * 10000) + '.png', //randomize the file name
+                  filename = scrshotDir + name;
+              fs.writeFileSync(filename, new Buffer(stepData.data, 'base64'));
+              step.image = 'screenshot/'+ name;
             }
             if(!step.result) {
               return 0;

--- a/templates/bootstrap/features.tmpl
+++ b/templates/bootstrap/features.tmpl
@@ -70,8 +70,8 @@ this.Then(/^<%= step.name.replace(/"[^"]*"/g, '"\(\[\^\"\]\*\)"') %>$/, function
 
                        <% if (step.image) { %>
                                                 <a class="toggle" href="#">Screenshot -</a>
-                                                <a class="screenshot" href="./<%= step.image %>">
-                                                 <img class="screenshot" style="height:100%;width:100%" id="my_images" src="./<%= step.image %>"/>
+                                                <a class="screenshot" href="<%= step.image %>">
+                                                 <img class="screenshot" style="height:100%;width:100%" id="my_images" src="<%= step.image %>"/>
                                                  </a>
                        <% } %>
 

--- a/templates/bootstrap/features.tmpl
+++ b/templates/bootstrap/features.tmpl
@@ -67,6 +67,14 @@ this.Then(/^<%= step.name.replace(/"[^"]*"/g, '"\(\[\^\"\]\*\)"') %>$/, function
                           <%= step.result.error_message %>
                         </div>
                       <% } %>
+
+                       <% if (step.image) { %>
+                                                <a class="toggle" href="#">Screenshot -</a>
+                                                <a class="screenshot" href="./<%= step.image %>">
+                                                 <img class="screenshot" style="height:100%;width:100%" id="my_images" src="./<%= step.image %>"/>
+                                                 </a>
+                       <% } %>
+
                     <% } %>
                     </p>              
                   <% }); %>

--- a/templates/bootstrap/index.tmpl
+++ b/templates/bootstrap/index.tmpl
@@ -52,8 +52,8 @@
     </div>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-    <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.5.1/moment.min.js"></script>
+    <script src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.5.1/moment.min.js"></script>
     <script>
       <%= script %>
     </script>

--- a/templates/bootstrap/script.js
+++ b/templates/bootstrap/script.js
@@ -7,8 +7,18 @@ $(document).ready(function() {
     $(this).prev().addClass('open');
   });
 
+  $('a.toggle').on('click', function(){
+    if($(this).text() === 'Screenshot -'){
+      $(this).text('Screenshot +');
+      $(this).siblings('a.screenshot').find('img').hide();
+    } else {
+      $(this).text('Screenshot -');
+      $(this).siblings('a.screenshot').find('img').show();
+    }
+  });
   var $generated = $('.generated-on');
 
   $generated.text('Generated ' + moment($generated.text()).fromNow());
+
 
 });

--- a/templates/foundation/features.tmpl
+++ b/templates/foundation/features.tmpl
@@ -39,8 +39,8 @@
 		<% } %>
 		 <% if (step.image) { %>
                  <a class="toggle" href="#">Screenshot -</a>
-                  <a class="screenshot" href="./<%= step.image %>">
-                      <img class="screenshot" style="height:100%;width:100%" id="my_images" src="./<%= step.image %>"/>
+                  <a class="screenshot" href="<%= step.image %>">
+                      <img class="screenshot" style="height:100%;width:100%" id="my_images" src="<%= step.image %>"/>
                    </a>
           <% } %>
               </p>              

--- a/templates/foundation/features.tmpl
+++ b/templates/foundation/features.tmpl
@@ -37,6 +37,12 @@
                 <% } %>
                 </small>
 		<% } %>
+		 <% if (step.image) { %>
+                 <a class="toggle" href="#">Screenshot -</a>
+                  <a class="screenshot" href="./<%= step.image %>">
+                      <img class="screenshot" style="height:100%;width:100%" id="my_images" src="./<%= step.image %>"/>
+                   </a>
+          <% } %>
               </p>              
 
               <% if (step.result && step.result.error_message) { %>

--- a/templates/foundation/index.tmpl
+++ b/templates/foundation/index.tmpl
@@ -25,9 +25,9 @@
 
     <%= features %>
 
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/foundation/5.2.2/js/foundation.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.5.1/moment.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/foundation/5.2.2/js/foundation.min.js"></script>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.5.1/moment.min.js"></script>
     <script>
       <%= script %>
     </script>

--- a/templates/foundation/script.js
+++ b/templates/foundation/script.js
@@ -35,3 +35,15 @@ function next(elem) {
     } while (elem && elem.nodeType !== 1);
     return elem;        
 }
+
+$(document).ready(function() {
+    $('a.toggle').on('click', function(){
+        if($(this).text() === 'Screenshot -'){
+            $(this).text('Screenshot +');
+            $(this).siblings('a.screenshot').find('img').hide();
+        } else {
+            $(this).text('Screenshot -');
+            $(this).siblings('a.screenshot').find('img').show();
+        }
+    });
+});

--- a/templates/simple/features.tmpl
+++ b/templates/simple/features.tmpl
@@ -12,6 +12,12 @@
             <span class="text <%= step.result.status %>">
             <% } %>
             <span class="keyword highlight"><%= step.keyword %></span> <%= step.name %></span>
+             <% if (step.image) { %>
+                   <a class="toggle" href="#">Screenshot -</a>
+                   <a class="screenshot" href="./<%= step.image %>">
+                      <img class="screenshot" style="height:100%;width:100%" id="my_images" src="./<%= step.image %>"/>
+                   </a>
+             <% } %>
           </p>
         </div>
       <% }); %> 

--- a/templates/simple/features.tmpl
+++ b/templates/simple/features.tmpl
@@ -14,8 +14,8 @@
             <span class="keyword highlight"><%= step.keyword %></span> <%= step.name %></span>
              <% if (step.image) { %>
                    <a class="toggle" href="#">Screenshot -</a>
-                   <a class="screenshot" href="./<%= step.image %>">
-                      <img class="screenshot" style="height:100%;width:100%" id="my_images" src="./<%= step.image %>"/>
+                   <a class="screenshot" href="<%= step.image %>">
+                      <img class="screenshot" style="height:100%;width:100%" id="my_images" src="<%= step.image %>"/>
                    </a>
              <% } %>
           </p>

--- a/templates/simple/index.tmpl
+++ b/templates/simple/index.tmpl
@@ -8,5 +8,9 @@
   </head>
   <body>
     <%= features %>
+     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+     <script>
+       <%= script %>
+     </script>
   </body>
 </html>

--- a/templates/simple/script.js
+++ b/templates/simple/script.js
@@ -1,0 +1,11 @@
+$(document).ready(function() {
+    $('a.toggle').on('click', function(){
+        if($(this).text() === 'Screenshot -'){
+            $(this).text('Screenshot +');
+            $(this).siblings('a.screenshot').find('img').hide();
+        } else {
+            $(this).text('Screenshot -');
+            $(this).siblings('a.screenshot').find('img').show();
+        }
+    });
+});


### PR DESCRIPTION
Two features added with this PR: 
- Now one can attach screenshots to html report in all three themes
- Added require option so that one can specify step_definitions if they are not in default location under features directory like ```features/step_definitions```

Check out the screenshots embedded in HTML below. FYI, JS to collapse/expand screenshots doesn't seem to work on the views below. However this has been thoroughly tested locally and everything works well.

http://htmlpreview.github.io/?https://github.com/nikulkarni/grunt-cucumberjs/blob/screenshot/report/cucumber_report_bootstrap.html

http://htmlpreview.github.io/?https://github.com/nikulkarni/grunt-cucumberjs/blob/screenshot/report/cucumber_report_simple.html

http://htmlpreview.github.io/?https://github.com/nikulkarni/grunt-cucumberjs/blob/screenshot/report/cucumber_report_foundation.html