### PR TITLE
Adding require to options + ignoring IDE folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 tmp
 .DS_Store
+.idea/

--- a/README.md
+++ b/README.md
@@ -59,11 +59,8 @@ cucumberjs: {
 #runs all features specified in task
 $ grunt cucumberjs
 
-#provide step_definitions and hooks if they are NOT in default location of ```features/step_definitions```
-$ grunt cucumberjs --require=test/functional/step_definitions/
-
 #you can override options via the cli
-$ grunt cucumberjs --features=features/myFeature.feature --format=pretty
+$ grunt cucumberjs --require=test/functional/step_definitions/ --features=features/myFeature.feature --format=pretty
 ```
 
 ### Options
@@ -72,7 +69,14 @@ $ grunt cucumberjs --features=features/myFeature.feature --format=pretty
 Type: `String`
 Default: `''`
 
-passes the value as ```--steps``` parameter to cucumber.
+Passes the value as ```--steps``` parameter to cucumber.
+
+#### options.require
+Type: `String`
+Default: `''`
+
+Passes the value as ```--require``` parameter to cucumber. If an array, each item is passed as a separate ```--require``` parameter.
+Use if step_definitions and hooks are NOT in default location of ```features/step_definitions```
 
 #### options.tags
 Type: `String|Array`

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -29,6 +29,7 @@ module.exports = function(grunt) {
       theme: 'foundation',
       templateDir: 'features/templates',
       tags: '',
+      require: '',
       debug: false
     });
 
@@ -59,6 +60,16 @@ module.exports = function(grunt) {
       commands.push('-f', 'json');
     } else {
       commands.push('-f', options.format);
+    }
+
+    if (options.require) {
+      if (options.require instanceof Array) {
+        options.require.forEach(function(element, index, array) {
+          commands.push('--require', element);
+        });
+      } else {
+        commands.push('--require', options.require);
+      }
     }
 
     if(grunt.option('require')) {


### PR DESCRIPTION
At the moment, you need to provide the step_definitions, hooks and the world through grunt options if they are not located under the default location of "features/step_definitions".
E.g.: $ grunt cucumberjs --require=test/functional/step_definitions/

While this is working, it would be nice to handle it together with other grunt-cucumberjs options (like the tags, format, etc).
This way you would be able to use grunt-cucumberjs with a "cleaner" call from the command line.
So you have these required path specified in the Grunfile.js
  ...
    cucumberjs: {
      options: {
        steps: 'features/step_definitions',
        format: 'html',
        templateDir: 'reports/template',
        output: 'reports/report.html',
        require: ["features/support/world.js", "features/support/hooks.js"]
      },
  ...

And from command line you can use only:
 $ grunt cucumberjs