### PR TITLE
Support for debugger from IDE's like webstorm

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,47 +10,52 @@
 
 module.exports = function(grunt) {
 
-  // Project configuration.
-  grunt.initConfig({
-    jshint: {
-      all: [
-        'Gruntfile.js',
-        'tasks/*.js'
-      ],
-      options: {
-        jshintrc: '.jshintrc',
-      },
-    },
+    // Project configuration.
+    grunt.initConfig({
+        jshint: {
+            all: [
+                'Gruntfile.js',
+                'package.json',
+                'tasks/*.js',
+                'features/**/*.js'
+            ],
+            options: {
+                jshintrc: '.jshintrc'
+            }
+        },
 
-    // Before generating any new files, remove any previously-created files.
-    clean: {
-      tests: ['tmp'],
-    },
+        // Before generating any new files, remove any previously-created files.
+        clean: {
+            tests: ['tmp']
+        },
 
-    // Configuration to be run (and then tested).
-    cucumberjs: {
+        // Configuration to be run (and then tested).
+        cucumberjs: {
 
-      options: {
-        steps: '',
-        tags: '',
-        templateDir: 'templates/simple',
-        output: 'tmp/features_report.html',
-        format: 'html',
-        cucumber: ''
-      },
-      features : []
-    }
+            options: {
+                steps: '',
+                tags: '',
+                templateDir: 'templates/simple',
+                output: 'tmp/features_report.html',
+                format: 'html',
+                cucumber: ''
+            },
+            features: []
+        },
+        jsbeautifier: {
+            src: ['<%= jshint.all %>']
+        }
+    });
 
-  });
+    // Actually load this plugin's task(s).
+    grunt.loadTasks('tasks');
 
-  // Actually load this plugin's task(s).
-  grunt.loadTasks('tasks');
+    // These plugins provide necessary tasks.
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-contrib-clean');
+    grunt.loadNpmTasks('grunt-jsbeautifier');
 
-  // These plugins provide necessary tasks.
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-
-  // By default, lint and run all tests.
-  grunt.registerTask('default', ['jshint', 'cucumberjs']);
+    // By default, lint and run all tests.
+    grunt.registerTask('default', ['jshint', 'jsbeautifier', 'cucumberjs']);
 
 };

--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ Available: `['true', 'false']`
 
 A flag to turn console log on or off
 
+#### options.debugger
+Type: `Boolean`
+Default: `'false'`
+Available: `['true', 'false']`
+
+A flag to enabling debuggin from IDE like WebStorm. Limitation of this flag is it only does not support the HTML output, yet ;)
+
 ### Attaching Screenshots to grunt-cucumberjs HTML report
 
 If you are using [WebDriverJS][1] (or related framework) along with [cucumber-js][2] for browser automation, you can attach screenshots to grunt-cucumberjs HTML report. Typically screenshots are taken after a test failure to help debug what went wrong when analyzing results, for example

--- a/features/step_definitions/test.js
+++ b/features/step_definitions/test.js
@@ -1,36 +1,36 @@
 var assert = require('assert');
 
 var steps = function() {
-  this.Given(/^I have a test scenario$/, function(callback) {
-  // express the regexp above with the code you wish you had
-  callback();
-  });
+    this.Given(/^I have a test scenario$/, function(callback) {
+        // express the regexp above with the code you wish you had
+        callback();
+    });
 
-  this.Given(/^I want to create test a feature$/, function(callback) {
-    // express the regexp above with the code you wish you had
-    callback();
-  });
+    this.Given(/^I want to create test a feature$/, function(callback) {
+        // express the regexp above with the code you wish you had
+        callback();
+    });
 
-  this.Given(/^the future is testable$/, function(callback) {
-    // express the regexp above with the code you wish you had
-    callback();
-  });
+    this.Given(/^the future is testable$/, function(callback) {
+        // express the regexp above with the code you wish you had
+        callback();
+    });
 
-  this.When(/^I choose "([^"]*)" output$/, function(arg1, callback) {
-    // express the regexp above with the code you wish you had
-    callback();
-  });
+    this.When(/^I choose "([^"]*)" output$/, function(arg1, callback) {
+        // express the regexp above with the code you wish you had
+        callback();
+    });
 
-  this.Then(/^I should see an "([^"]*)"$/, function(arg1, callback) {
-    // express the regexp above with the code you wish you had
-    callback();
-  });
+    this.Then(/^I should see an "([^"]*)"$/, function(arg1, callback) {
+        // express the regexp above with the code you wish you had
+        callback();
+    });
 
-  this.Then(/^the output should contain test results$/, function(callback) {
-    // express the regexp above with the code you wish you had
-    callback();
-  });
-}
+    this.Then(/^the output should contain test results$/, function(callback) {
+        // express the regexp above with the code you wish you had
+        callback();
+    });
+};
 
 
 module.exports = steps;

--- a/lib/processHandler.js
+++ b/lib/processHandler.js
@@ -1,0 +1,213 @@
+'use strict';
+
+module.exports = function HandleUsingProcess(grunt, options, commands, callback) {
+
+    var fs = require('fs');
+    var version = grunt.file.readJSON('./package.json').version;
+    var projectPkg = grunt.file.readJSON('package.json');
+    var spawn = require('child_process').spawn;
+    var _ = require('underscore');
+    var commondir = require('commondir');
+
+    var WIN32_BIN_PATH = 'node_modules\\.bin\\cucumber-js.cmd';
+    var UNIX_BIN_PATH = 'node_modules/cucumber/bin/cucumber.js';
+
+    var buffer = [];
+    var cucumber;
+    var binPath = '';
+
+    if (process.platform === 'win32') {
+        binPath = WIN32_BIN_PATH;
+    } else {
+        binPath = UNIX_BIN_PATH;
+    }
+
+    if (!grunt.file.exists(binPath)) {
+        grunt.log.error('cucumberjs binary not found at path ' + binPath + '\n NOTE: You cannot install grunt-cucumberjs without bin links on windows');
+        return callback(false);
+    }
+
+    cucumber = spawn(binPath, commands);
+
+    cucumber.stdout.on('data', function(data) {
+        if (options.format === 'html') {
+            if (options.debug) {
+                process.stdout.write(data);
+            }
+            buffer.push(data);
+        } else {
+            grunt.log.write(data);
+        }
+    });
+
+    cucumber.stderr.on('data', function(data) {
+        if (options.debug) {
+            process.stdout.write(data);
+        }
+        var stderr = new Buffer(data);
+        grunt.log.error(stderr.toString());
+    });
+
+    cucumber.on('close', function(code) {
+        if (options.format === 'html') {
+            var featureJsonOutput;
+
+            var output = Buffer.concat(buffer).toString();
+
+            var featureStartIndex = output.substring(0, output.indexOf('"keyword": "Feature"')).lastIndexOf('[');
+
+            var logOutput = output.substring(0, featureStartIndex - 1);
+
+            var featureOutput = output.substring(featureStartIndex);
+
+            try {
+                //console.log('#####JSON output', featureOutput);
+                featureJsonOutput = JSON.parse(featureOutput);
+            } catch (e) {
+                grunt.log.error('Unable to parse cucumberjs output into json.');
+
+                return callback(false);
+            }
+
+            generateReport(featureJsonOutput, logOutput);
+        }
+
+        return callback(code);
+    });
+
+    /**
+     * Adds passed/failed properties on features/scenarios
+     *
+     * @param {object} suite The test suite object
+     */
+    var setStats = function(suite) {
+        var features = suite.features;
+        var rootDir = commondir(_.pluck(features, 'uri'));
+        var scrshotDir;
+        if (options.output.lastIndexOf('/') > -1) {
+            scrshotDir = options.output.substring(0, options.output.lastIndexOf('/')) + '/screenshot/';
+        } else {
+            scrshotDir = 'screenshot/';
+        }
+        features.forEach(function(feature) {
+            feature.passed = 0;
+            feature.failed = 0;
+            feature.relativeFolder = feature.uri.slice(rootDir.length);
+
+            if (!feature.elements) {
+                return;
+            }
+
+            feature.elements.forEach(function(element) {
+                element.passed = 0;
+                element.failed = 0;
+                element.notdefined = 0;
+                element.skipped = 0;
+
+                element.steps.forEach(function(step) {
+                    if (step.embeddings !== undefined) {
+                        if (!fs.existsSync(scrshotDir)) {
+                            fs.mkdirSync(scrshotDir);
+                        }
+                        var stepData = step.embeddings[0],
+                            name = step.name && step.name.split(' ').join('_') || step.keyword.trim();
+                        name = name + Math.round(Math.random() * 10000) + '.png'; //randomize the file name
+                        var filename = scrshotDir + name;
+                        fs.writeFile(filename, new Buffer(stepData.data, 'base64'), function(err) {
+                            if (err) {
+                                console.error('Error saving screenshot ' + filename); //asynchronously save screenshot
+                            }
+                        });
+                        step.image = 'screenshot/' + name;
+                    }
+                    if (!step.result) {
+                        return 0;
+                    }
+                    if (step.result.status === 'passed') {
+                        return element.passed++;
+                    }
+                    if (step.result.status === 'failed') {
+                        return element.failed++;
+                    }
+                    if (step.result.status === 'undefined') {
+                        return element.notdefined++;
+                    }
+
+                    element.skipped++;
+                });
+
+                if (element.failed > 0) {
+                    return feature.failed++;
+                }
+                if (element.passed > 0) {
+                    return feature.passed++;
+                }
+            });
+
+            if (feature.failed > 0) {
+                return suite.failed++;
+            }
+            if (feature.passed > 0) {
+                return suite.passed++;
+            }
+        });
+
+        suite.features = features;
+
+        return suite;
+    };
+
+    /**
+     * Returns the path of a template
+     *
+     * @param {string} name The template name
+     */
+    var getPath = function(name) {
+        var path = 'node_modules/grunt-cucumberjs/templates/' + options.theme + '/' + name;
+        // return the users custom template if it has been defined
+        if (grunt.file.exists(options.templateDir + '/' + name)) {
+            path = options.templateDir + '/' + name;
+        }
+
+        return path;
+    };
+
+    /**
+     * Generate html report
+     *
+     * @param {object} featureOutput Features result object
+     * @param {string} logOutput Contains any console statements captured during the test run
+     */
+    var generateReport = function(featureOutput, logOutput) {
+        var suite = {
+            name: projectPkg.name,
+            features: featureOutput,
+            passed: 0,
+            failed: 0,
+            logOutput: logOutput
+        };
+
+        suite = setStats(suite);
+
+        if (options.saveJson) {
+            grunt.file.write(options.output + '.json', JSON.stringify(featureOutput, null, '\t'));
+        }
+        grunt.file.write(
+            options.output,
+            _.template(grunt.file.read(getPath('index.tmpl')))({
+                suite: suite,
+                version: version,
+                time: new Date(),
+                features: _.template(grunt.file.read(getPath('features.tmpl')))({
+                    suite: suite,
+                    _: _
+                }),
+                styles: grunt.file.read(getPath('style.css')),
+                script: grunt.file.read(getPath('script.js'))
+            })
+        );
+
+        grunt.log.writeln('Generated ' + options.output + ' successfully.');
+    };
+
+};

--- a/lib/requireHandler.js
+++ b/lib/requireHandler.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = function HandleUsingRequire(grunt, options, commands, callback) {
+
+    var Cucumber = require('cucumber'),
+        argv = ['node', 'cucumber-js'];
+
+    argv.push.apply(argv, commands);
+
+    function runtimeCallback() {
+        var succeeded = arguments[0];
+        if (succeeded) {
+            callback();
+        } else {
+            callback(new Error("Cucumber tests failed!"));
+        }
+    }
+
+    Cucumber.Cli(argv).run(runtimeCallback);
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grunt-cucumberjs",
     "description": "Generates documentation from Cucumber features",
-    "version": "0.5.2",
+    "version": "0.6.0",
     "homepage": "https://github.com/mavdi/grunt-cucumberjs",
     "author": {
         "name": "Mehdi Avdi",
@@ -35,6 +35,7 @@
         "test": "grunt"
     },
     "devDependencies": {
+        "cucumber": "^0.4.8",
         "grunt": "~0.4.5",
         "grunt-cli": "~0.1.13",
         "grunt-contrib-clean": "~0.5.0",
@@ -48,7 +49,6 @@
         "gruntplugin"
     ],
     "dependencies": {
-        "cucumber": "~0.3.1",
         "handlebars": "~1.0.12",
         "underscore": "~1.5.2",
         "commondir": "~0.0.1"

--- a/package.json
+++ b/package.json
@@ -1,59 +1,56 @@
 {
-  "name": "grunt-cucumberjs",
-  "description": "Generates documentation from Cucumber features",
-  "version": "0.5.2",
-  "homepage": "https://github.com/mavdi/grunt-cucumberjs",
-  "author": {
-    "name": "Mehdi Avdi",
-    "email": "mehdi.avdi@gmail.com"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/mavdi/grunt-cucumberjs.git"
-  },
-
-  "contributors" : [
-    { "name" : "Andrew Keig",
-     "email" : "andrew.keig@gmail.com",
-     "url" : "https://github.com/AndrewKeig"
+    "name": "grunt-cucumberjs",
+    "description": "Generates documentation from Cucumber features",
+    "version": "0.5.2",
+    "homepage": "https://github.com/mavdi/grunt-cucumberjs",
+    "author": {
+        "name": "Mehdi Avdi",
+        "email": "mehdi.avdi@gmail.com"
     },
-    { "name" : "Jozz Hart",
-     "email" : "me@jozzhart.com",
-     "url" : "http://jozzhart.com"
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/mavdi/grunt-cucumberjs.git"
+    },
+    "contributors": [{
+        "name": "Andrew Keig",
+        "email": "andrew.keig@gmail.com",
+        "url": "https://github.com/AndrewKeig"
+    }, {
+        "name": "Jozz Hart",
+        "email": "me@jozzhart.com",
+        "url": "http://jozzhart.com"
+    }],
+    "bugs": {
+        "url": "https://github.com/mavdi/grunt-cucumberjs/issues"
+    },
+    "licenses": [{
+        "type": "MIT",
+        "url": "https://github.com/mavdi/grunt-cucumberjs/blob/master/LICENSE-MIT"
+    }],
+    "main": "Gruntfile.js",
+    "engines": {
+        "node": ">= 0.8.0"
+    },
+    "scripts": {
+        "test": "grunt"
+    },
+    "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "~0.5.0",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-jsbeautifier": "^0.2.10"
+    },
+    "peerDependencies": {
+        "grunt": "~0.4.5"
+    },
+    "keywords": [
+        "gruntplugin"
+    ],
+    "dependencies": {
+        "cucumber": "~0.3.1",
+        "handlebars": "~1.0.12",
+        "underscore": "~1.5.2",
+        "commondir": "~0.0.1"
     }
-  ],
-
-  "bugs": {
-    "url": "https://github.com/mavdi/grunt-cucumberjs/issues"
-  },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/mavdi/grunt-cucumberjs/blob/master/LICENSE-MIT"
-    }
-  ],
-  "main": "Gruntfile.js",
-  "engines": {
-    "node": ">= 0.8.0"
-  },
-  "scripts": {
-    "test": "grunt"
-  },
-  "devDependencies": {
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-clean": "~0.5.0",
-    "grunt-cli": "~0.1.13",
-    "grunt": "~0.4.5"
-  },
-  "peerDependencies": {
-    "grunt": "~0.4.5"
-  },
-  "keywords": [
-    "gruntplugin"
-  ],
-  "dependencies": {
-    "handlebars": "~1.0.12",
-    "underscore": "~1.5.2",
-    "commondir": "~0.0.1"
-  }
 }

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -7,18 +7,7 @@
  */
 
 'use strict';
-var fs = require('fs');
 module.exports = function(grunt) {
-
-    var version = grunt.file.readJSON('./package.json').version;
-    var projectPkg = grunt.file.readJSON('package.json');
-    var spawn = require('child_process').spawn;
-    var _ = require('underscore');
-    var commondir = require('commondir');
-
-    var WIN32_BIN_PATH = 'node_modules\\.bin\\cucumber-js.cmd';
-    var UNIX_BIN_PATH = 'node_modules/cucumber/bin/cucumber.js';
-
     grunt.registerMultiTask('cucumberjs', 'Run cucumber.js features', function() {
         var done = this.async();
 
@@ -30,8 +19,11 @@ module.exports = function(grunt) {
             templateDir: 'features/templates',
             tags: '',
             require: '',
-            debug: false
+            debug: false,
+            debugger: false
         });
+
+        var handler = options.debugger ? require('../lib/requireHandler') : require('../lib/processHandler');
 
         // resolve options set via cli
         for (var key in options) {
@@ -91,207 +83,14 @@ module.exports = function(grunt) {
             });
         }
 
-        var buffer = [];
-        var cucumber;
-        var binPath = '';
-
-        if (process.platform === 'win32') {
-            binPath = WIN32_BIN_PATH;
-        } else {
-            binPath = UNIX_BIN_PATH;
-        }
-
-        if (!grunt.file.exists(binPath)) {
-            grunt.log.error('cucumberjs binary not found at path ' + binPath + '\n NOTE: You cannot install grunt-cucumberjs without bin links on windows');
-            return done(false);
-        }
-
-        cucumber = spawn(binPath, commands);
-
-        cucumber.stdout.on('data', function(data) {
-            if (options.format === 'html') {
-                if (options.debug) {
-                    process.stdout.write(data);
-                }
-                buffer.push(data);
-            } else {
-                grunt.log.write(data);
-            }
-        });
-
-        cucumber.stderr.on('data', function(data) {
-            if (options.debug) {
-                process.stdout.write(data);
-            }
-            var stderr = new Buffer(data);
-            grunt.log.error(stderr.toString());
-        });
-
-        cucumber.on('close', function(code) {
-            if (options.format === 'html') {
-                var featureJsonOutput;
-
-                var output = Buffer.concat(buffer).toString();
-
-                var featureStartIndex = output.substring(0, output.indexOf('"keyword": "Feature"')).lastIndexOf('[');
-
-                var logOutput = output.substring(0, featureStartIndex - 1);
-
-                var featureOutput = output.substring(featureStartIndex);
-
-                try {
-                    featureJsonOutput = JSON.parse(featureOutput);
-                } catch (e) {
-                    grunt.log.error('Unable to parse cucumberjs output into json.');
-
-                    return done(false);
-                }
-
-                generateReport(featureJsonOutput, logOutput);
-            }
-
-            if (code !== 0) {
+        handler(grunt, options, commands, function handlerCallback(err) {
+            if (err) {
                 grunt.log.error('failed tests, please see the output');
-
                 return done(false);
             } else {
                 return done();
             }
         });
 
-        /**
-         * Adds passed/failed properties on features/scenarios
-         *
-         * @param {object} suite The test suite object
-         */
-        var setStats = function(suite) {
-            var features = suite.features;
-            var rootDir = commondir(_.pluck(features, 'uri'));
-            var scrshotDir;
-            if (options.output.lastIndexOf('/') > -1) {
-                scrshotDir = options.output.substring(0, options.output.lastIndexOf('/')) + '/screenshot/';
-            } else {
-                scrshotDir = 'screenshot/';
-            }
-            features.forEach(function(feature) {
-                feature.passed = 0;
-                feature.failed = 0;
-                feature.relativeFolder = feature.uri.slice(rootDir.length);
-
-                if (!feature.elements) {
-                    return;
-                }
-
-                feature.elements.forEach(function(element) {
-                    element.passed = 0;
-                    element.failed = 0;
-                    element.notdefined = 0;
-                    element.skipped = 0;
-
-                    element.steps.forEach(function(step) {
-                        if (step.embeddings !== undefined) {
-                            if (!fs.existsSync(scrshotDir)) {
-                                fs.mkdirSync(scrshotDir);
-                            }
-                            var stepData = step.embeddings[0],
-                                name = step.name && step.name.split(' ').join('_') || step.keyword.trim();
-                            name = name + Math.round(Math.random() * 10000) + '.png'; //randomize the file name
-                            var filename = scrshotDir + name;
-                            fs.writeFile(filename, new Buffer(stepData.data, 'base64'), function(err) {
-                                if (err) {
-                                    console.error('Error saving screenshot ' + filename); //asynchronously save screenshot
-                                }
-                            });
-                            step.image = 'screenshot/' + name;
-                        }
-                        if (!step.result) {
-                            return 0;
-                        }
-                        if (step.result.status === 'passed') {
-                            return element.passed++;
-                        }
-                        if (step.result.status === 'failed') {
-                            return element.failed++;
-                        }
-                        if (step.result.status === 'undefined') {
-                            return element.notdefined++;
-                        }
-
-                        element.skipped++;
-                    });
-
-                    if (element.failed > 0) {
-                        return feature.failed++;
-                    }
-                    if (element.passed > 0) {
-                        return feature.passed++;
-                    }
-                });
-
-                if (feature.failed > 0) {
-                    return suite.failed++;
-                }
-                if (feature.passed > 0) {
-                    return suite.passed++;
-                }
-            });
-
-            suite.features = features;
-
-            return suite;
-        };
-
-        /**
-         * Returns the path of a template
-         *
-         * @param {string} name The template name
-         */
-        var getPath = function(name) {
-            var path = 'node_modules/grunt-cucumberjs/templates/' + options.theme + '/' + name;
-            // return the users custom template if it has been defined
-            if (grunt.file.exists(options.templateDir + '/' + name)) {
-                path = options.templateDir + '/' + name;
-            }
-
-            return path;
-        };
-
-        /**
-         * Generate html report
-         *
-         * @param {object} featureOutput Features result object
-         * @param {string} logOutput Contains any console statements captured during the test run
-         */
-        var generateReport = function(featureOutput, logOutput) {
-            var suite = {
-                name: projectPkg.name,
-                features: featureOutput,
-                passed: 0,
-                failed: 0,
-                logOutput: logOutput
-            };
-
-            suite = setStats(suite);
-
-            if (options.saveJson) {
-                grunt.file.write(options.output + '.json', JSON.stringify(featureOutput, null, '\t'));
-            }
-            grunt.file.write(
-                options.output,
-                _.template(grunt.file.read(getPath('index.tmpl')))({
-                    suite: suite,
-                    version: version,
-                    time: new Date(),
-                    features: _.template(grunt.file.read(getPath('features.tmpl')))({
-                        suite: suite,
-                        _: _
-                    }),
-                    styles: grunt.file.read(getPath('style.css')),
-                    script: grunt.file.read(getPath('script.js'))
-                })
-            );
-
-            grunt.log.writeln('Generated ' + options.output + ' successfully.');
-        };
     });
 };

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -1,294 +1,297 @@
 /*
-* grunt-cucumberjs
-* https://github.com/mavdi/grunt-cucumberjs
-*
-* Copyright (c) 2013 Mehdi Avdi
-* Licensed under the MIT license.
-*/
+ * grunt-cucumberjs
+ * https://github.com/mavdi/grunt-cucumberjs
+ *
+ * Copyright (c) 2013 Mehdi Avdi
+ * Licensed under the MIT license.
+ */
 
 'use strict';
 var fs = require('fs');
 module.exports = function(grunt) {
 
-  var version = grunt.file.readJSON('./package.json').version;
-  var projectPkg = grunt.file.readJSON('package.json');
-  var spawn = require('child_process').spawn;
-  var _ = require('underscore');
-  var commondir = require('commondir');
+    var version = grunt.file.readJSON('./package.json').version;
+    var projectPkg = grunt.file.readJSON('package.json');
+    var spawn = require('child_process').spawn;
+    var _ = require('underscore');
+    var commondir = require('commondir');
 
-  var WIN32_BIN_PATH = 'node_modules\\.bin\\cucumber-js.cmd';
-  var UNIX_BIN_PATH = 'node_modules/cucumber/bin/cucumber.js';
+    var WIN32_BIN_PATH = 'node_modules\\.bin\\cucumber-js.cmd';
+    var UNIX_BIN_PATH = 'node_modules/cucumber/bin/cucumber.js';
 
-  grunt.registerMultiTask('cucumberjs', 'Run cucumber.js features', function() {
-    var done = this.async();
+    grunt.registerMultiTask('cucumberjs', 'Run cucumber.js features', function() {
+        var done = this.async();
 
-    var options = this.options({
-      output: 'features_report.html',
-      format: 'html',
-      saveJson: false,
-      theme: 'foundation',
-      templateDir: 'features/templates',
-      tags: '',
-      require: '',
-      debug: false
-    });
-
-    // resolve options set via cli
-    for (var key in options) {
-      if (grunt.option(key)) {
-        options[key] = grunt.option(key);
-      }
-    }
-
-    var commands = [];
-
-    if (options.steps) {
-      commands.push('-r', options.steps);
-    }
-
-    if (options.tags) {
-      if (options.tags instanceof Array) {
-        options.tags.forEach(function(element, index, array) {
-          commands.push('-t', element);
-        });
-      } else {
-        commands.push('-t', options.tags);
-      }
-    }
-
-    if (options.format === 'html') {
-      commands.push('-f', 'json');
-    } else {
-      commands.push('-f', options.format);
-    }
-
-    if (options.require) {
-      if (options.require instanceof Array) {
-        options.require.forEach(function(element, index, array) {
-          commands.push('--require', element);
-        });
-      } else {
-        commands.push('--require', options.require);
-      }
-    }
-
-    if(grunt.option('require')) {
-      commands.push('--require', grunt.option('require'));
-    }
-
-    if (grunt.option('features')) {
-      commands.push(grunt.option('features'));
-    } else {
-      this.files.forEach(function(f) {
-        f.src.forEach(function(filepath) {
-          if (!grunt.file.exists(filepath)) {
-            grunt.log.warn('Source file "' + filepath + '" not found.');
-            return;
-          }
-
-          commands.push(filepath);
-        });
-      });
-    }
-
-    var buffer  = [];
-    var cucumber;
-    var binPath = '';
-
-    if (process.platform === 'win32') {
-      binPath = WIN32_BIN_PATH;
-    } else {
-      binPath = UNIX_BIN_PATH;
-    }
-
-    if(!grunt.file.exists(binPath)) {
-      grunt.log.error('cucumberjs binary not found at path ' + binPath + '\n NOTE: You cannot install grunt-cucumberjs without bin links on windows');
-      return done(false);
-    }
-
-    cucumber = spawn(binPath, commands);
-
-    cucumber.stdout.on('data', function(data) {
-      if (options.format === 'html') {
-        if (options.debug) {
-         process.stdout.write(data);
-        }
-        buffer.push(data);
-      } else {
-        grunt.log.write(data);
-      }
-    });
-
-    cucumber.stderr.on('data', function (data) {
-      if (options.debug) {
-         process.stdout.write(data);
-      }
-      var stderr = new Buffer(data);
-      grunt.log.error(stderr.toString());
-    });
-
-    cucumber.on('close', function (code) {
-      if (options.format === 'html') {
-        var featureJsonOutput;
-
-        var output = Buffer.concat(buffer).toString();
-
-        var featureStartIndex = output.substring(0, output.indexOf('"keyword": "Feature"')).lastIndexOf('[');
-
-        var logOutput = output.substring(0, featureStartIndex - 1);
-
-        var featureOutput = output.substring(featureStartIndex);
-
-        try {
-          featureJsonOutput = JSON.parse(featureOutput);
-        } catch (e) {
-          grunt.log.error('Unable to parse cucumberjs output into json.');
-
-          return done(false);
-        }
-
-        generateReport(featureJsonOutput, logOutput);
-      }
-
-      if (code !== 0) {
-        grunt.log.error('failed tests, please see the output');
-
-        return done(false);
-      } else {
-        return done();
-      }
-    });
-
-    /**
-    * Adds passed/failed properties on features/scenarios
-    *
-    * @param {object} suite The test suite object
-    */
-    var setStats = function(suite) {
-      var features = suite.features;
-      var rootDir = commondir(_.pluck(features, 'uri'));
-      var scrshotDir;
-      if(options.output.lastIndexOf('/')>-1) {
-        scrshotDir  = options.output.substring(0, options.output.lastIndexOf('/')) + '/screenshot/';
-      } else {
-        scrshotDir = 'screenshot/';
-      }
-      features.forEach(function(feature) {
-        feature.passed = 0;
-        feature.failed = 0;
-        feature.relativeFolder = feature.uri.slice(rootDir.length);
-
-        if(!feature.elements) {
-          return;
-        }
-
-        feature.elements.forEach(function(element) {
-          element.passed = 0;
-          element.failed = 0;
-          element.notdefined = 0;
-          element.skipped = 0;
-
-          element.steps.forEach(function(step) {
-            if (step.embeddings !== undefined) {
-              if(!fs.existsSync(scrshotDir)){
-                fs.mkdirSync(scrshotDir);
-              }
-              var stepData = step.embeddings[0],
-                  name= step.name && step.name.split(' ').join('_')|| step.keyword.trim(),
-                  name = name + Math.round(Math.random() * 10000) + '.png', //randomize the file name
-                  filename = scrshotDir + name;
-              fs.writeFile(filename, new Buffer(stepData.data, 'base64'), function(err) {
-                  if(err){
-                    console.error('Error saving screenshot '+filename); //asynchronously save screenshot
-                  }
-              });
-              step.image = 'screenshot/'+ name;
-            }
-            if(!step.result) {
-              return 0;
-            }
-            if(step.result.status === 'passed') {
-              return element.passed++;
-            }
-            if(step.result.status === 'failed') {
-              return element.failed++;
-            }
-            if(step.result.status === 'undefined') {
-              return element.notdefined++;
-            }
-
-            element.skipped ++;
-          });
-
-          if(element.failed > 0) {
-            return feature.failed++;
-          }
-          if (element.passed > 0) {
-            return feature.passed++;
-          }
+        var options = this.options({
+            output: 'features_report.html',
+            format: 'html',
+            saveJson: false,
+            theme: 'foundation',
+            templateDir: 'features/templates',
+            tags: '',
+            require: '',
+            debug: false
         });
 
-        if(feature.failed > 0) {
-          return suite.failed++;
+        // resolve options set via cli
+        for (var key in options) {
+            if (grunt.option(key)) {
+                options[key] = grunt.option(key);
+            }
         }
-        if(feature.passed > 0) {
-          return suite.passed++;
+
+        var commands = [];
+
+        if (options.steps) {
+            commands.push('-r', options.steps);
         }
-      });
 
-      suite.features = features;
+        if (options.tags) {
+            if (options.tags instanceof Array) {
+                options.tags.forEach(function(element, index, array) {
+                    commands.push('-t', element);
+                });
+            } else {
+                commands.push('-t', options.tags);
+            }
+        }
 
-      return suite;
-    };
+        if (options.format === 'html') {
+            commands.push('-f', 'json');
+        } else {
+            commands.push('-f', options.format);
+        }
 
-    /**
-    * Returns the path of a template
-    *
-    * @param {string} name The template name
-    */
-    var getPath = function(name) {
-      var path = 'node_modules/grunt-cucumberjs/templates/' + options.theme + '/' + name;
-      // return the users custom template if it has been defined
-      if (grunt.file.exists(options.templateDir + '/' + name)) {
-        path = options.templateDir + '/' + name;
-      }
+        if (options.require) {
+            if (options.require instanceof Array) {
+                options.require.forEach(function(element, index, array) {
+                    commands.push('--require', element);
+                });
+            } else {
+                commands.push('--require', options.require);
+            }
+        }
 
-      return path;
-    };
+        if (grunt.option('require')) {
+            commands.push('--require', grunt.option('require'));
+        }
 
-    /**
-    * Generate html report
-    *
-    * @param {object} featureOutput Features result object
-    * @param {string} logOutput Contains any console statements captured during the test run
-    */
-    var generateReport = function(featureOutput, logOutput) {
-      var suite = {
-        name: projectPkg.name,
-        features: featureOutput,
-        passed: 0,
-        failed: 0,
-        logOutput: logOutput
-      };
+        if (grunt.option('features')) {
+            commands.push(grunt.option('features'));
+        } else {
+            this.files.forEach(function(f) {
+                f.src.forEach(function(filepath) {
+                    if (!grunt.file.exists(filepath)) {
+                        grunt.log.warn('Source file "' + filepath + '" not found.');
+                        return;
+                    }
 
-      suite = setStats(suite);
+                    commands.push(filepath);
+                });
+            });
+        }
 
-      if (options.saveJson) {
-        grunt.file.write(options.output+'.json', JSON.stringify(featureOutput, null, '\t'));
-      }
-      grunt.file.write(
-        options.output,
-        _.template(grunt.file.read(getPath('index.tmpl')))({
-          suite: suite,
-          version: version,
-          time: new Date(),
-          features: _.template(grunt.file.read(getPath('features.tmpl')))({suite : suite, _ : _ }),
-          styles: grunt.file.read(getPath('style.css')),
-          script: grunt.file.read(getPath('script.js'))
-        })
-      );
+        var buffer = [];
+        var cucumber;
+        var binPath = '';
 
-      grunt.log.writeln('Generated ' + options.output + ' successfully.');
-    };
-  });
+        if (process.platform === 'win32') {
+            binPath = WIN32_BIN_PATH;
+        } else {
+            binPath = UNIX_BIN_PATH;
+        }
+
+        if (!grunt.file.exists(binPath)) {
+            grunt.log.error('cucumberjs binary not found at path ' + binPath + '\n NOTE: You cannot install grunt-cucumberjs without bin links on windows');
+            return done(false);
+        }
+
+        cucumber = spawn(binPath, commands);
+
+        cucumber.stdout.on('data', function(data) {
+            if (options.format === 'html') {
+                if (options.debug) {
+                    process.stdout.write(data);
+                }
+                buffer.push(data);
+            } else {
+                grunt.log.write(data);
+            }
+        });
+
+        cucumber.stderr.on('data', function(data) {
+            if (options.debug) {
+                process.stdout.write(data);
+            }
+            var stderr = new Buffer(data);
+            grunt.log.error(stderr.toString());
+        });
+
+        cucumber.on('close', function(code) {
+            if (options.format === 'html') {
+                var featureJsonOutput;
+
+                var output = Buffer.concat(buffer).toString();
+
+                var featureStartIndex = output.substring(0, output.indexOf('"keyword": "Feature"')).lastIndexOf('[');
+
+                var logOutput = output.substring(0, featureStartIndex - 1);
+
+                var featureOutput = output.substring(featureStartIndex);
+
+                try {
+                    featureJsonOutput = JSON.parse(featureOutput);
+                } catch (e) {
+                    grunt.log.error('Unable to parse cucumberjs output into json.');
+
+                    return done(false);
+                }
+
+                generateReport(featureJsonOutput, logOutput);
+            }
+
+            if (code !== 0) {
+                grunt.log.error('failed tests, please see the output');
+
+                return done(false);
+            } else {
+                return done();
+            }
+        });
+
+        /**
+         * Adds passed/failed properties on features/scenarios
+         *
+         * @param {object} suite The test suite object
+         */
+        var setStats = function(suite) {
+            var features = suite.features;
+            var rootDir = commondir(_.pluck(features, 'uri'));
+            var scrshotDir;
+            if (options.output.lastIndexOf('/') > -1) {
+                scrshotDir = options.output.substring(0, options.output.lastIndexOf('/')) + '/screenshot/';
+            } else {
+                scrshotDir = 'screenshot/';
+            }
+            features.forEach(function(feature) {
+                feature.passed = 0;
+                feature.failed = 0;
+                feature.relativeFolder = feature.uri.slice(rootDir.length);
+
+                if (!feature.elements) {
+                    return;
+                }
+
+                feature.elements.forEach(function(element) {
+                    element.passed = 0;
+                    element.failed = 0;
+                    element.notdefined = 0;
+                    element.skipped = 0;
+
+                    element.steps.forEach(function(step) {
+                        if (step.embeddings !== undefined) {
+                            if (!fs.existsSync(scrshotDir)) {
+                                fs.mkdirSync(scrshotDir);
+                            }
+                            var stepData = step.embeddings[0],
+                                name = step.name && step.name.split(' ').join('_') || step.keyword.trim();
+                            name = name + Math.round(Math.random() * 10000) + '.png'; //randomize the file name
+                            var filename = scrshotDir + name;
+                            fs.writeFile(filename, new Buffer(stepData.data, 'base64'), function(err) {
+                                if (err) {
+                                    console.error('Error saving screenshot ' + filename); //asynchronously save screenshot
+                                }
+                            });
+                            step.image = 'screenshot/' + name;
+                        }
+                        if (!step.result) {
+                            return 0;
+                        }
+                        if (step.result.status === 'passed') {
+                            return element.passed++;
+                        }
+                        if (step.result.status === 'failed') {
+                            return element.failed++;
+                        }
+                        if (step.result.status === 'undefined') {
+                            return element.notdefined++;
+                        }
+
+                        element.skipped++;
+                    });
+
+                    if (element.failed > 0) {
+                        return feature.failed++;
+                    }
+                    if (element.passed > 0) {
+                        return feature.passed++;
+                    }
+                });
+
+                if (feature.failed > 0) {
+                    return suite.failed++;
+                }
+                if (feature.passed > 0) {
+                    return suite.passed++;
+                }
+            });
+
+            suite.features = features;
+
+            return suite;
+        };
+
+        /**
+         * Returns the path of a template
+         *
+         * @param {string} name The template name
+         */
+        var getPath = function(name) {
+            var path = 'node_modules/grunt-cucumberjs/templates/' + options.theme + '/' + name;
+            // return the users custom template if it has been defined
+            if (grunt.file.exists(options.templateDir + '/' + name)) {
+                path = options.templateDir + '/' + name;
+            }
+
+            return path;
+        };
+
+        /**
+         * Generate html report
+         *
+         * @param {object} featureOutput Features result object
+         * @param {string} logOutput Contains any console statements captured during the test run
+         */
+        var generateReport = function(featureOutput, logOutput) {
+            var suite = {
+                name: projectPkg.name,
+                features: featureOutput,
+                passed: 0,
+                failed: 0,
+                logOutput: logOutput
+            };
+
+            suite = setStats(suite);
+
+            if (options.saveJson) {
+                grunt.file.write(options.output + '.json', JSON.stringify(featureOutput, null, '\t'));
+            }
+            grunt.file.write(
+                options.output,
+                _.template(grunt.file.read(getPath('index.tmpl')))({
+                    suite: suite,
+                    version: version,
+                    time: new Date(),
+                    features: _.template(grunt.file.read(getPath('features.tmpl')))({
+                        suite: suite,
+                        _: _
+                    }),
+                    styles: grunt.file.read(getPath('style.css')),
+                    script: grunt.file.read(getPath('script.js'))
+                })
+            );
+
+            grunt.log.writeln('Generated ' + options.output + ' successfully.');
+        };
+    });
 };


### PR DESCRIPTION
This will fix #18. Currently enabling debugger=true does not support html output. I will spend more time to  support html report in future. I am considering supporting multiple report formats.

But for now having support for debugging from IDE helps a lot. I will appreciate if you get this merged and published to npm.