### PR TITLE
Use regex to detect feature json start

### DIFF
--- a/features/test.feature
+++ b/features/test.feature
@@ -1,5 +1,5 @@
 Feature: Test Feature
-  Test Description
+  Test Description with a bracket [
 
   Background: 
     Given I have a background element

--- a/lib/processHandler.js
+++ b/lib/processHandler.js
@@ -54,7 +54,7 @@ module.exports = function HandleUsingProcess(grunt, options, commands, callback)
 
             var output = Buffer.concat(buffer).toString();
 
-            var featureStartIndex = output.substring(0, output.indexOf('"keyword": "Feature"')).lastIndexOf('[');
+            var featureStartIndex = output.search(/\[\s*{\s*\"id\"/g);
 
             var logOutput = output.substring(0, featureStartIndex - 1);
 


### PR DESCRIPTION
The previous method was breaking if the description had a '[' in it.

Using this RegEx, we look for the structure of the start of the json.

