### PR TITLE
Add step text

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ this.After(function (scenario, callback) {
         }
 });
 ```
+
+### Add texts to the cucumber steps to grunt-cucumberjs HTML report
+
+If you are using [WebDriverJS][1] (or related framework) along with [cucumber-js][2] for browser automation, you can attach texts to grunt-cucumberjs HTML report. This helps in debugging or reviewing your results in particular to your tests data. 
+
+```javascript
+this.After(function (scenario, callback) {
+        
+                scenario.attach("test data goes here");
+
+});
+```
 Below are some sample HTML reports with screenshots (note that javascript to collapse/expand a screenshots doesn't appear to respond in htmlpreview site below, but they should work fine on locally generated reports,
 
 1. [Bootstrap Theme Reports][3]

--- a/lib/processHandler.js
+++ b/lib/processHandler.js
@@ -110,10 +110,10 @@ module.exports = function HandleUsingProcess(grunt, options, commands, callback)
                         step.embeddings.forEach(function (embedding) {
 
                             if (embedding.mime_type === "text/plain") {
-                                if (step.text === undefined) {
+                                if (!step.text) {
                                     step.text = Base64.decode(embedding.data)
                                 } else {
-                                    step.text = step.text + '<br>' + Base64.decode(embedding.data);
+                                    step.text = step.text.concat('<br>' + Base64.decode(embedding.data));
                         }
                             }else if(embedding.mime_type === "image/png"){
                                 var stepData = step.embeddings[0],

--- a/lib/processHandler.js
+++ b/lib/processHandler.js
@@ -115,7 +115,7 @@ module.exports = function HandleUsingProcess(grunt, options, commands, callback)
                                 } else {
                                     step.text = step.text.concat('<br>' + Base64.decode(embedding.data));
                         }
-                            }else if(embedding.mime_type === "image/png"){
+                            }else {
                                 var stepData = step.embeddings[0],
                                     name = step.name && step.name.split(' ').join('_') || step.keyword.trim();
                                 if (!fs.existsSync(scrshotDir)) {

--- a/lib/processHandler.js
+++ b/lib/processHandler.js
@@ -108,7 +108,6 @@ module.exports = function HandleUsingProcess(grunt, options, commands, callback)
                     if (step.embeddings !== undefined) {
                         var Base64 = require('js-base64').Base64;
                         step.embeddings.forEach(function (embedding) {
-
                             if (embedding.mime_type === "text/plain") {
                                 if (!step.text) {
                                     step.text = Base64.decode(embedding.data)

--- a/lib/processHandler.js
+++ b/lib/processHandler.js
@@ -106,20 +106,33 @@ module.exports = function HandleUsingProcess(grunt, options, commands, callback)
 
                 element.steps.forEach(function(step) {
                     if (step.embeddings !== undefined) {
-                        if (!fs.existsSync(scrshotDir)) {
-                            fs.mkdirSync(scrshotDir);
+                        var Base64 = require('js-base64').Base64;
+                        step.embeddings.forEach(function (embedding) {
+
+                            if (embedding.mime_type === "text/plain") {
+                                if (step.text === undefined) {
+                                    step.text = Base64.decode(embedding.data)
+                                } else {
+                                    step.text = step.text + '<br>' + Base64.decode(embedding.data);
                         }
-                        var stepData = step.embeddings[0],
-                            name = step.name && step.name.split(' ').join('_') || step.keyword.trim();
-                        name = name + Math.round(Math.random() * 10000) + '.png'; //randomize the file name
-                        var filename = scrshotDir + name;
-                        fs.writeFile(filename, new Buffer(stepData.data, 'base64'), function(err) {
-                            if (err) {
-                                console.error('Error saving screenshot ' + filename); //asynchronously save screenshot
+                            }else if(embedding.mime_type === "image/png"){
+                                var stepData = step.embeddings[0],
+                                    name = step.name && step.name.split(' ').join('_') || step.keyword.trim();
+                                if (!fs.existsSync(scrshotDir)) {
+                                    fs.mkdirSync(scrshotDir);
+                                }
+                                name = name + Math.round(Math.random() * 10000) + '.png'; //randomize the file name
+                                var filename = scrshotDir + name;
+                                fs.writeFile(filename, new Buffer(embedding.data, 'base64'), function (err) {
+                                    if (err) {
+                                        console.error('Error saving screenshot ' + filename); //asynchronously save screenshot
+                                    }
+                                });
+                                step.image = 'screenshot/' + name;
                             }
                         });
-                        step.image = 'screenshot/' + name;
                     }
+
                     if (!step.result) {
                         return 0;
                     }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "dependencies": {
         "handlebars": "~1.0.12",
         "underscore": "~1.5.2",
-        "commondir": "~0.0.1”,
+        "commondir": "~0.0.1",
         "js-base64": "^2.1.8"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grunt-cucumberjs",
     "description": "Generates documentation from Cucumber features",
-    "version": "0.7.2",
+    "version": “0.7.3”,
     "homepage": "https://github.com/mavdi/grunt-cucumberjs",
     "author": {
         "name": "Mehdi Avdi",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grunt-cucumberjs",
     "description": "Generates documentation from Cucumber features",
-    "version": "0.7.1",
+    "version": “0.7.2”,
     "homepage": "https://github.com/mavdi/grunt-cucumberjs",
     "author": {
         "name": "Mehdi Avdi",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grunt-cucumberjs",
     "description": "Generates documentation from Cucumber features",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "homepage": "https://github.com/mavdi/grunt-cucumberjs",
     "author": {
         "name": "Mehdi Avdi",
@@ -40,7 +40,8 @@
         "grunt-cli": "~0.1.13",
         "grunt-contrib-clean": "~0.5.0",
         "grunt-contrib-jshint": "~0.10.0",
-        "grunt-jsbeautifier": "^0.2.10"
+        "grunt-jsbeautifier": "^0.2.10",
+        "js-base64": "^2.1.8"
     },
     "peerDependencies": {
         "grunt": "~0.4.5"

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
         "grunt-cli": "~0.1.13",
         "grunt-contrib-clean": "~0.5.0",
         "grunt-contrib-jshint": "~0.10.0",
-        "grunt-jsbeautifier": "^0.2.10",
-        "js-base64": "^2.1.8"
+        "grunt-jsbeautifier": "^0.2.10"
     },
     "peerDependencies": {
         "grunt": "~0.4.5"
@@ -52,6 +51,7 @@
     "dependencies": {
         "handlebars": "~1.0.12",
         "underscore": "~1.5.2",
-        "commondir": "~0.0.1"
+        "commondir": "~0.0.1”,
+        "js-base64": "^2.1.8"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grunt-cucumberjs",
     "description": "Generates documentation from Cucumber features",
-    "version": “0.7.2”,
+    "version": "0.7.2",
     "homepage": "https://github.com/mavdi/grunt-cucumberjs",
     "author": {
         "name": "Mehdi Avdi",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grunt-cucumberjs",
     "description": "Generates documentation from Cucumber features",
-    "version": “0.7.3”,
+    "version": "0.7.3",
     "homepage": "https://github.com/mavdi/grunt-cucumberjs",
     "author": {
         "name": "Mehdi Avdi",

--- a/templates/bootstrap/features.tmpl
+++ b/templates/bootstrap/features.tmpl
@@ -68,6 +68,13 @@ this.Then(/^<%= step.name.replace(/"[^"]*"/g, '"\(\[\^\"\]\*\)"') %>$/, function
                         </div>
                       <% } %>
 
+                      <% if (step.text) { %>
+                           <a href="#error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" data-toggle="collapse">+ Show Text</a>
+                           <div id="error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" class="collapse">
+                             <%= step.text %>
+                           </div>
+                      <% } %>
+
                        <% if (step.image) { %>
                                                 <a class="toggle" href="#">Screenshot -</a>
                                                 <a class="screenshot" href="<%= step.image %>">

--- a/templates/bootstrap/features.tmpl
+++ b/templates/bootstrap/features.tmpl
@@ -69,7 +69,7 @@ this.Then(/^<%= step.name.replace(/"[^"]*"/g, '"\(\[\^\"\]\*\)"') %>$/, function
                       <% } %>
 
                       <% if (step.text) { %>
-                           <a href="#error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" data-toggle="collapse">+ Show Text</a>
+                           <a href="#error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" data-toggle="collapse">+ Show Info</a>
                            <div id="error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" class="collapse">
                              <%= step.text %>
                            </div>

--- a/templates/foundation/features.tmpl
+++ b/templates/foundation/features.tmpl
@@ -39,7 +39,7 @@
 		<% } %>
 
         <% if (step.text) { %>
-             <a href="#error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" data-toggle="collapse">+ Show Text</a>
+             <a href="#error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" data-toggle="collapse">+ Show Info</a>
              <div id="error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" class="collapse">
                <%= step.text %>
              </div>

--- a/templates/foundation/features.tmpl
+++ b/templates/foundation/features.tmpl
@@ -37,6 +37,14 @@
                 <% } %>
                 </small>
 		<% } %>
+
+        <% if (step.text) { %>
+             <a href="#error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" data-toggle="collapse">+ Show Text</a>
+             <div id="error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" class="collapse">
+               <%= step.text %>
+             </div>
+        <% } %>
+
 		 <% if (step.image) { %>
                  <a class="toggle" href="#">Screenshot -</a>
                   <a class="screenshot" href="<%= step.image %>">

--- a/templates/simple/features.tmpl
+++ b/templates/simple/features.tmpl
@@ -12,6 +12,13 @@
             <span class="text <%= step.result.status %>">
             <% } %>
             <span class="keyword highlight"><%= step.keyword %></span> <%= step.name %></span>
+             <% if (step.text) { %>
+                   <div id="error">
+                     <br>
+                     <%= step.text %>
+                   </div>
+             <% } %>
+
              <% if (step.image) { %>
                    <a class="toggle" href="#">Screenshot -</a>
                    <a class="screenshot" href="<%= step.image %>">


### PR DESCRIPTION
It is important to print the scenario level information to the report for ease of review and debug the failed scenarios. These information can be anything, e.g. user, product id's, remote job urls etc. 

Scenario level information can be added through the `scenario.attach("type your information here...")` function. It will add the information to the GWT steps. Please see the sceenshot below,

<img width="1335" alt="screen shot 2015-07-27 at 9 25 03 pm" src="https://cloud.githubusercontent.com/assets/3663389/8921666/feec226c-34a6-11e5-96ba-014945c5ebaa.png">
