### PR TITLE
Parallel execution - v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,20 @@ Available: `['true', 'false']`
 
 A flag to enabling debuggin from IDE like WebStorm. Limitation of this flag is it only does not support the HTML output, yet ;)
 
+#### options.executeParallel
+Type: `Boolean`
+Default: `'undefined'`
+Available: `['true', 'false']`
+
+A flag to enable Parallel execution. It requires dependency on [parallel-cucumber][6] npmjs module
+
+#### options.workers
+Type: `Number`
+Default: `'8'`
+Available: `'1 to 8'`
+
+The number of features that will be executed in parallel.
+
 ### Attaching Screenshots to grunt-cucumberjs HTML report
 
 If you are using [WebDriverJS][1] (or related framework) along with [cucumber-js][2] for browser automation, you can attach screenshots to grunt-cucumberjs HTML report. Typically screenshots are taken after a test failure to help debug what went wrong when analyzing results, for example
@@ -169,3 +183,4 @@ Below are some sample HTML reports with screenshots (note that javascript to col
 [3]: http://htmlpreview.github.io/?https://github.com/nikulkarni/grunt-cucumberjs/blob/screenshot/report/cucumber_report_bootstrap.html "Bootstrap Theme Reports"
 [4]: http://htmlpreview.github.io/?https://github.com/nikulkarni/grunt-cucumberjs/blob/screenshot/report/cucumber_report_simple.html "Simple Theme Reports"
 [5]: http://htmlpreview.github.io/?https://github.com/nikulkarni/grunt-cucumberjs/blob/screenshot/report/cucumber_report_foundation.html "Foundation Theme Reports"
+[6]: https://www.npmjs.com/package/parallel-cucumber

--- a/lib/processHandler.js
+++ b/lib/processHandler.js
@@ -9,8 +9,16 @@ module.exports = function HandleUsingProcess(grunt, options, commands, callback)
     var _ = require('underscore');
     var commondir = require('commondir');
 
-    var WIN32_BIN_PATH = 'node_modules\\.bin\\cucumber-js.cmd';
-    var UNIX_BIN_PATH = 'node_modules/cucumber/bin/cucumber.js';
+    var WIN32_BIN_PATH,
+		UNIX_BIN_PATH;
+
+	if (options.executeParallel) {
+		UNIX_BIN_PATH = 'node_modules/parallel-cucumber/bin/parallel-cucumber-js';
+		WIN32_BIN_PATH = 'node_modules\\parallel-cucumber\\bin\\parallel-cucumber-js';
+	} else {
+		WIN32_BIN_PATH = 'node_modules\\.bin\\cucumber-js.cmd';
+		UNIX_BIN_PATH = 'node_modules/cucumber/bin/cucumber.js';
+	}
 
     var buffer = [];
     var cucumber;
@@ -23,7 +31,11 @@ module.exports = function HandleUsingProcess(grunt, options, commands, callback)
     }
 
     if (!grunt.file.exists(binPath)) {
-        grunt.log.error('cucumberjs binary not found at path ' + binPath + '\n NOTE: You cannot install grunt-cucumberjs without bin links on windows');
+		if(options.executeParallel) {
+			grunt.log.error('parallel-cucumber-js binary not found at path ' + binPath + '\n NOTE: You cannot install grunt-cucumberjs without bin links on windows');
+		} else {
+			grunt.log.error('cucumberjs binary not found at path ' + binPath + '\n NOTE: You cannot install grunt-cucumberjs without bin links on windows');
+		}
         return callback(false);
     }
 
@@ -50,19 +62,24 @@ module.exports = function HandleUsingProcess(grunt, options, commands, callback)
 
     cucumber.on('close', function(code) {
         if (options.format === 'html') {
-            var featureJsonOutput;
 
-            var output = Buffer.concat(buffer).toString();
+			var featureJsonOutput,
+				featureOutput;
 
-            var featureStartIndex = output.search(/\[\s*{\s*\"id\"/g);
+			if (options.executeParallel) {
+				featureOutput = JSON.stringify(require('jsonfile').readFileSync(options.output + '.json'));
+			} else {
+				var output = Buffer.concat(buffer).toString();
 
-            var logOutput = output.substring(0, featureStartIndex - 1);
+				var featureStartIndex = output.search(/\[\s*{\s*\"id\"/g);
 
-            var featureOutput = output.substring(featureStartIndex);
+				var logOutput = output.substring(0, featureStartIndex - 1);
+
+				featureOutput = output.substring(featureStartIndex);
+			}
 
             try {
-                //console.log('#####JSON output', featureOutput);
-                featureJsonOutput = JSON.parse(featureOutput);
+				featureJsonOutput = JSON.parse(featureOutput);
             } catch (e) {
                 grunt.log.error('Unable to parse cucumberjs output into json.');
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "handlebars": "~1.0.12",
         "underscore": "~1.5.2",
         "commondir": "~0.0.1",
+        "jsonfile": "^2.2.1",
         "js-base64": "^2.1.8"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grunt-cucumberjs",
     "description": "Generates documentation from Cucumber features",
-    "version": "0.7.3",
+    "version": "1.0.0",
     "homepage": "https://github.com/mavdi/grunt-cucumberjs",
     "author": {
         "name": "Mehdi Avdi",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
         "name": "Jozz Hart",
         "email": "me@jozzhart.com",
         "url": "http://jozzhart.com"
+    }, {
+        "name": "Kushang Gajjar",
+        "email": "g.kushang@gmail.com",
+        "url": "https://github.com/gkushang"
     }],
     "bugs": {
         "url": "https://github.com/mavdi/grunt-cucumberjs/issues"

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -34,6 +34,10 @@ module.exports = function(grunt) {
 
         var commands = [];
 
+		if (options.executeParallel && options.workers) {
+			commands.push('-w', options.workers);
+		}
+
         if (options.steps) {
             commands.push('-r', options.steps);
         }
@@ -49,7 +53,10 @@ module.exports = function(grunt) {
         }
 
         if (options.format === 'html') {
-            commands.push('-f', 'json');
+			if(options.executeParallel) {
+				commands.push('-f', 'json:' + options.output +'.json');
+			} else {
+			    commands.push('-f', 'json');
         } else {
             commands.push('-f', options.format);
         }

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -34,9 +34,9 @@ module.exports = function(grunt) {
 
         var commands = [];
 
-		if (options.executeParallel && options.workers) {
-			commands.push('-w', options.workers);
-		}
+        if (options.executeParallel && options.workers) {
+            commands.push('-w', options.workers);
+        }
 
         if (options.steps) {
             commands.push('-r', options.steps);
@@ -44,7 +44,7 @@ module.exports = function(grunt) {
 
         if (options.tags) {
             if (options.tags instanceof Array) {
-                options.tags.forEach(function(element, index, array) {
+                options.tags.forEach(function (element, index, array) {
                     commands.push('-t', element);
                 });
             } else {
@@ -53,17 +53,18 @@ module.exports = function(grunt) {
         }
 
         if (options.format === 'html') {
-			if(options.executeParallel) {
-				commands.push('-f', 'json:' + options.output +'.json');
-			} else {
-			    commands.push('-f', 'json');
+            if (options.executeParallel) {
+                commands.push('-f', 'json:' + options.output + '.json');
+            } else {
+                commands.push('-f', 'json');
+            }
         } else {
             commands.push('-f', options.format);
         }
 
         if (options.require) {
             if (options.require instanceof Array) {
-                options.require.forEach(function(element, index, array) {
+                options.require.forEach(function (element, index, array) {
                     commands.push('--require', element);
                 });
             } else {
@@ -78,8 +79,8 @@ module.exports = function(grunt) {
         if (grunt.option('features')) {
             commands.push(grunt.option('features'));
         } else {
-            this.files.forEach(function(f) {
-                f.src.forEach(function(filepath) {
+            this.files.forEach(function (f) {
+                f.src.forEach(function (filepath) {
                     if (!grunt.file.exists(filepath)) {
                         grunt.log.warn('Source file "' + filepath + '" not found.');
                         return;


### PR DESCRIPTION
* Adding support to execute Cucumber features Parallel - its controlled by the user with flag to enable this feature
* User can enable Parallel execution by `options.executeParallel: true`
* If Parallel execution is requested then use cucumber runner from [parallel-cucumber](https://www.npmjs.com/package/parallel-cucumber)
* Number of workers can be defined through `options.workers`