### PR TITLE
a fix when feature element does not have steps

### DIFF
--- a/lib/processHandler.js
+++ b/lib/processHandler.js
@@ -121,49 +121,51 @@ module.exports = function HandleUsingProcess(grunt, options, commands, callback)
                 element.notdefined = 0;
                 element.skipped = 0;
 
-                element.steps.forEach(function(step) {
-                    if (step.embeddings !== undefined) {
-                        var Base64 = require('js-base64').Base64;
-                        step.embeddings.forEach(function (embedding) {
-                            if (embedding.mime_type === "text/plain") {
-                                if (!step.text) {
-                                    step.text = Base64.decode(embedding.data)
-                                } else {
-                                    step.text = step.text.concat('<br>' + Base64.decode(embedding.data));
-                        }
-                            }else {
-                                var stepData = step.embeddings[0],
-                                    name = step.name && step.name.split(' ').join('_') || step.keyword.trim();
-                                if (!fs.existsSync(scrshotDir)) {
-                                    fs.mkdirSync(scrshotDir);
-                                }
-                                name = name + Math.round(Math.random() * 10000) + '.png'; //randomize the file name
-                                var filename = scrshotDir + name;
-                                fs.writeFile(filename, new Buffer(embedding.data, 'base64'), function (err) {
-                                    if (err) {
-                                        console.error('Error saving screenshot ' + filename); //asynchronously save screenshot
+                if(element.steps) {
+                    element.steps.forEach(function (step) {
+                        if (step.embeddings !== undefined) {
+                            var Base64 = require('js-base64').Base64;
+                            step.embeddings.forEach(function (embedding) {
+                                if (embedding.mime_type === "text/plain") {
+                                    if (!step.text) {
+                                        step.text = Base64.decode(embedding.data)
+                                    } else {
+                                        step.text = step.text.concat('<br>' + Base64.decode(embedding.data));
                                     }
-                                });
-                                step.image = 'screenshot/' + name;
-                            }
-                        });
-                    }
+                                } else {
+                                    var stepData = step.embeddings[0],
+                                        name = step.name && step.name.split(' ').join('_') || step.keyword.trim();
+                                    if (!fs.existsSync(scrshotDir)) {
+                                        fs.mkdirSync(scrshotDir);
+                                    }
+                                    name = name + Math.round(Math.random() * 10000) + '.png'; //randomize the file name
+                                    var filename = scrshotDir + name;
+                                    fs.writeFile(filename, new Buffer(embedding.data, 'base64'), function (err) {
+                                        if (err) {
+                                            console.error('Error saving screenshot ' + filename); //asynchronously save screenshot
+                                        }
+                                    });
+                                    step.image = 'screenshot/' + name;
+                                }
+                            });
+                        }
 
-                    if (!step.result) {
-                        return 0;
-                    }
-                    if (step.result.status === 'passed') {
-                        return element.passed++;
-                    }
-                    if (step.result.status === 'failed') {
-                        return element.failed++;
-                    }
-                    if (step.result.status === 'undefined') {
-                        return element.notdefined++;
-                    }
+                        if (!step.result) {
+                            return 0;
+                        }
+                        if (step.result.status === 'passed') {
+                            return element.passed++;
+                        }
+                        if (step.result.status === 'failed') {
+                            return element.failed++;
+                        }
+                        if (step.result.status === 'undefined') {
+                            return element.notdefined++;
+                        }
 
-                    element.skipped++;
-                });
+                        element.skipped++;
+                    });
+                }
 
                 if (element.failed > 0) {
                     return feature.failed++;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grunt-cucumberjs",
     "description": "Generates documentation from Cucumber features",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "homepage": "https://github.com/mavdi/grunt-cucumberjs",
     "author": {
         "name": "Mehdi Avdi",


### PR DESCRIPTION
a fix when feature element does not have steps. `setState` should continue reading next elements. It happens at the beginning of feature json

```
"elements": [
	{
		"name": "Fred is able to login",
		"id": "Login;fred-is-able-to-login",
		"line": 10,
		"keyword": "Scenario",
		"description": "",
		"type": "scenario",
		"tags": [
			{
				"name": "@success_login",
				"line": 9
			},
			{
				"name": "@smoke",
				"line": 9
			}
		]
	},

```