### PR TITLE
fix options.tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grunt-cucumberjs",
     "description": "Generates documentation from Cucumber features",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "homepage": "https://github.com/mavdi/grunt-cucumberjs",
     "author": {
         "name": "Mehdi Avdi",

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -28,7 +28,13 @@ module.exports = function(grunt) {
         // resolve options set via cli
         for (var key in options) {
             if (grunt.option(key)) {
-                options[key] = grunt.option(key);
+                if(key === 'tags') {
+                    if(options.tags === '') {
+                        options[key] = grunt.option(key);
+                    }
+                }else {
+                    options[key] = grunt.option(key);
+                }
             }
         }
 


### PR DESCRIPTION
When cucumber.js resolves the CLI args, it overwrites the user's tags. This fix will make sure user's tags are also included in the tags array and appends whatever has been passed as `--tags` CLI arg.

for e.g. user's cucumber.js task defines not to run tags `~@todo, ~@wip` , this fix will make sure that these tags are included when user runs `grunt cucumbejs --tags=@happyScenarios` - this command will include tags `['@happyScenarios','~@todo','~@wip']`
