### PR TITLE
Add support for the --fail-fast option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,7 +38,8 @@ module.exports = function(grunt) {
                 templateDir: 'templates/simple',
                 output: 'tmp/features_report.html',
                 format: 'html',
-                cucumber: ''
+                cucumber: '',
+                failFast:false
             },
             features: []
         },

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ Available: `['true', 'false']`
 To keep or not the generated json file, applicable for options.format = html only.
 It will be saved as options.output + '.json'
 
+#### options.failFast
+Type: `Boolean`
+Default: `'false'`
+Available: `['true', 'false']`
+
+ends the suite after the first failure
+
 #### options.debug
 Type: `Boolean`
 Default: `'false'`

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -20,7 +20,8 @@ module.exports = function(grunt) {
             tags: '',
             require: '',
             debug: false,
-            debugger: false
+            debugger: false,
+            failFast: false
         });
 
         var handler = options.debugger ? require('../lib/requireHandler') : require('../lib/processHandler');
@@ -66,6 +67,10 @@ module.exports = function(grunt) {
             }
         } else {
             commands.push('-f', options.format);
+        }
+
+        if (options.failFast || grunt.option('fail-fast')) {
+            commands.push('--fail-fast');
         }
 
         if (options.require) {


### PR DESCRIPTION
There is a new feature in cucumberjs (that is yet to be documentet on the readme) that allows the test-suite to stop executing if one test fails.

You can either add failFast to the task options or pass --fail-fast via the command-line.