### PR TITLE
Fixed div id for Show Info button in HTML report

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-cucumberjs",
   "description": "Generates documentation from Cucumber features",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "homepage": "https://github.com/mavdi/grunt-cucumberjs",
   "author": {
     "name": "Mehdi Avdi",

--- a/templates/bootstrap/features.tmpl
+++ b/templates/bootstrap/features.tmpl
@@ -71,8 +71,8 @@ this.Then(/^<%= step.name.replace(/"[^"]*"/g, '"\(\[\^\"\]\*\)"') %>$/, function
                       <% } %>
 
                       <% if (step.text) { %>
-                           <a href="#error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" data-toggle="collapse">+ Show Info</a>
-                           <div id="error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" class="collapse">
+                           <a href="#info<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" data-toggle="collapse">+ Show Info</a>
+                           <div id="info<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" class="collapse">
                              <%= step.text %>
                            </div>
                       <% } %>

--- a/templates/foundation/features.tmpl
+++ b/templates/foundation/features.tmpl
@@ -39,8 +39,8 @@
 		<% } %>
 
         <% if (step.text) { %>
-             <a href="#error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" data-toggle="collapse">+ Show Info</a>
-             <div id="error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" class="collapse">
+             <a href="#info<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" data-toggle="collapse">+ Show Info</a>
+             <div id="info<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" class="collapse">
                <%= step.text %>
              </div>
         <% } %>


### PR DESCRIPTION
Currently, in the HTML reports, we see that Show Info button expands the Error Div. This fix is to correct the DIV `id` of the Info content.