### PR TITLE
Rerun Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,19 @@ Default: `undefined`
 
 Rerun the failed scenarios recorded in the `@rerun.txt` file.
 
-e.g. `--rerun=/path/to/@rerun.txt`. If `@rerun.txt` is generated at projects root level then, `--rerun=@rerun.txt`
+To Re-run failed scenarios:
+
+* Set the cucumber-js task format to `rerun:@rerun.txt`
+```
+options: {
+     format: 'rerun:@rerun.txt',
+     .....
+     ....
+}
+```
+It will record all the faile scenarios to `@rerun.txt`
+
+* Run failed scenarios by passing `--rerun=path/to/@rerun.txt` grunt option
 
 ### Attaching Screenshots to grunt-cucumberjs HTML report
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ Available: `'1 to 8'`
 
 The number of features that will be executed in parallel.
 
+#### options.rerun
+Type: `String`
+Default: `undefined`
+
+Rerun the failed scenarios recorded in the `@rerun.txt` file.
+
+e.g. `--rerun=/path/to/@rerun.txt`. If `@rerun.txt` is generated at projects root level then, `--rerun=@rerun.txt`
+
 ### Attaching Screenshots to grunt-cucumberjs HTML report
 
 If you are using [WebDriverJS][1] (or related framework) along with [cucumber-js][2] for browser automation, you can attach screenshots to grunt-cucumberjs HTML report. Typically screenshots are taken after a test failure to help debug what went wrong when analyzing results, for example

--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ options: {
      ....
 }
 ```
-It will record all the faile scenarios to `@rerun.txt`
+It will record all the faile scenarios to `@rerun.txt`. 
+Please note that it won't generate HTML report due to change in the format
 
 * Run failed scenarios by passing `--rerun=path/to/@rerun.txt` grunt option
 

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -41,6 +41,10 @@ module.exports = function(grunt) {
 
         var commands = [];
 
+        if (grunt.option('rerun')) {
+            commands.push(grunt.option('rerun'));
+        }
+
         if (options.executeParallel && options.workers) {
             commands.push('-w', options.workers);
         }


### PR DESCRIPTION
Resolves https://github.com/mavdi/grunt-cucumberjs/issues/52


#### options.rerun
Type: `String`
Default: `undefined`

Rerun the failed scenarios recorded in the `@rerun.txt` file.

To Re-run failed scenarios:

* Set the cucumber-js task format to `rerun:@rerun.txt`
```
options: {
     format: 'rerun:@rerun.txt',
     .....
     ....
}
```
It will record all the faile scenarios to `@rerun.txt`

* Run failed scenarios by passing `--rerun=path/to/@rerun.txt` grunt option
Please note that, there is an open issue on Cucumber-js related to running `@rerun.txt` https://github.com/cucumber/cucumber-js/issues/499 