### PR TITLE
Support for Multi formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,17 @@ Available: `['true', 'false']`
 
 ends the suite after the first failure
 
+it can also be activated without setting `options.failFast` and passing `--fail-fast` as a grunt task option
+
+#### options.dryRun
+Type: `Boolean`
+Default: `'false'`
+Available: `['true', 'false']`
+
+dry-run the suite and provides snippets for pending steps
+
+it can also be activated without setting `options.dryRun` and passing `--dry-run` as a grunt task option
+
 #### options.debug
 Type: `Boolean`
 Default: `'false'`

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Available: `['pretty', 'progress', 'summary', 'html']`
 
 e.g. `formats: ['html', 'pretty']`
 
-Note: `html` formatter will provide Json as well as `html` report
+Note: `html` formatter will provide Json as well as `html` report. Multiple formatter is supported for cucumber v@0.8.0 or higher
 
 #### options.saveJson
 Type: `Boolean`
@@ -163,6 +163,28 @@ Available: `'1 to 8'`
 The number of features that will be executed in parallel.
 
 Note: This feature is supported for cucumber v@0.7.0 or lesser
+
+#### options.rerun
+Type: `String`
+Default: `undefined`
+
+Rerun the failed scenarios recorded in the `@rerun.txt` file.
+
+To Re-run failed scenarios:
+
+* Set the cucumber-js task format to `rerun:@rerun.txt`
+```
+options: {
+     format: 'rerun:@rerun.txt',
+     .....
+     ....
+}
+```
+It will record all the failed scenarios to `@rerun.txt`. 
+
+Take a look at `options.formats` to generate html report
+
+* Run failed scenarios by passing `--rerun=path/to/@rerun.txt` grunt option
 
 ### Attaching Screenshots to grunt-cucumberjs HTML report
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ Type: `String`
 Default: `'html'`
 Available: `['pretty', 'progress', 'summary', 'html']`
 
+#### options.formats
+Supports multiple formatter.
+Type: `Array`
+Available: `['pretty', 'progress', 'summary', 'html']`
+
+e.g. `formats: ['html', 'pretty']`
+
+Note: `html` formatter will provide Json as well as `html` report
+
 #### options.saveJson
 Type: `Boolean`
 Default: `'false'`
@@ -135,7 +144,7 @@ Type: `Boolean`
 Default: `'false'`
 Available: `['true', 'false']`
 
-A flag to enabling debuggin from IDE like WebStorm. Limitation of this flag is it only does not support the HTML output, yet ;)
+A flag to enabling debugging from IDE like WebStorm. Limitation of this flag is it only does not support the HTML output, yet ;)
 
 #### options.executeParallel
 Type: `Boolean`
@@ -144,6 +153,8 @@ Available: `['true', 'false']`
 
 A flag to enable Parallel execution. It requires dependency on [parallel-cucumber][6] npmjs module
 
+Note: This feature is supported for cucumber v@0.7.0 or lesser
+
 #### options.workers
 Type: `Number`
 Default: `'8'`
@@ -151,26 +162,7 @@ Available: `'1 to 8'`
 
 The number of features that will be executed in parallel.
 
-#### options.rerun
-Type: `String`
-Default: `undefined`
-
-Rerun the failed scenarios recorded in the `@rerun.txt` file.
-
-To Re-run failed scenarios:
-
-* Set the cucumber-js task format to `rerun:@rerun.txt`
-```
-options: {
-     format: 'rerun:@rerun.txt',
-     .....
-     ....
-}
-```
-It will record all the faile scenarios to `@rerun.txt`. 
-Please note that it won't generate HTML report due to change in the format
-
-* Run failed scenarios by passing `--rerun=path/to/@rerun.txt` grunt option
+Note: This feature is supported for cucumber v@0.7.0 or lesser
 
 ### Attaching Screenshots to grunt-cucumberjs HTML report
 
@@ -191,7 +183,7 @@ this.After(function (scenario, callback) {
 
 ### Add texts to the cucumber steps to grunt-cucumberjs HTML report
 
-If you are using [WebDriverJS][1] (or related framework) along with [cucumber-js][2] for browser automation, you can attach texts to grunt-cucumberjs HTML report. This helps in debugging or reviewing your results in particular to your tests data. 
+If you are using [WebDriverJS][1] (or related framework) along with [cucumber-js][2] for browser automation, you can attach texts to grunt-cucumberjs HTML report. This helps in debugging or reviewing your results in particular to your tests data.
 
 ```javascript
 this.After(function (scenario, callback) {

--- a/lib/processHandler.js
+++ b/lib/processHandler.js
@@ -3,6 +3,7 @@
 module.exports = function HandleUsingProcess(grunt, options, commands, callback) {
 
     var fs = require('fs');
+	var jsonFile = require('jsonfile');
     var version = grunt.file.readJSON('./package.json').version;
     var projectPkg = grunt.file.readJSON('package.json');
     var spawn = require('child_process').spawn;
@@ -42,7 +43,7 @@ module.exports = function HandleUsingProcess(grunt, options, commands, callback)
     cucumber = spawn(binPath, commands);
 
     cucumber.stdout.on('data', function(data) {
-        if (options.format === 'html') {
+        if (options.isHtml) {
             if (options.debug) {
                 process.stdout.write(data);
             }
@@ -61,21 +62,28 @@ module.exports = function HandleUsingProcess(grunt, options, commands, callback)
     });
 
     cucumber.on('close', function(code) {
-        if (options.format === 'html') {
+        if (options.isHtml) {
 
 			var featureJsonOutput,
 				featureOutput;
 
 			if (options.executeParallel) {
-				featureOutput = JSON.stringify(require('jsonfile').readFileSync(options.output + '.json'));
+				featureOutput = JSON.stringify(jsonFile.readFileSync(options.output + '.json'));
 			} else {
-				var output = Buffer.concat(buffer).toString();
+				var jsonOutputFilePath = options.output + '.json';
+				var jsonOutput;
 
-				var featureStartIndex = output.search(/\[\s*{\s*\"id\"/g);
+				if (fs.existsSync(options.output + '.json')) {
+					jsonOutput= JSON.stringify(jsonFile.readFileSync(jsonOutputFilePath));
+				} else {
+					jsonOutput = Buffer.concat(buffer).toString();
+				}
 
-				var logOutput = output.substring(0, featureStartIndex - 1);
+				var featureStartIndex = jsonOutput.search(/\[\s*{\s*\"id\"/g);
 
-				featureOutput = output.substring(featureStartIndex);
+				var logOutput = jsonOutput.substring(0, featureStartIndex - 1);
+
+				featureOutput = jsonOutput.substring(featureStartIndex);
 			}
 
             try {

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -37,7 +37,7 @@ module.exports = function(grunt) {
             } else {
                 commands.push('-f', options.format);
             }
-        }
+        };
 
         // resolve options set via cli
         for (var key in options) {
@@ -85,8 +85,12 @@ module.exports = function(grunt) {
             applyLegacyFormatters();
         }
 
-        if (options.failFast || grunt.option('fail-fast')) {
+        if (options.failFast || grunt.option('fail-fast') || grunt.cli.options['fail-fast'] === true) {
             commands.push('--fail-fast');
+        }
+
+        if (options.dryRun || grunt.option('dry-run') || grunt.cli.options['dry-run'] === true) {
+            commands.push('--dry-run');
         }
 
         if (options.require) {


### PR DESCRIPTION
#### options.formats
Supports multiple formatter.
Type: `Array`
Available: `['pretty', 'progress', 'summary', 'html']`

e.g. `formats: ['html', 'pretty']`

Note: `html` formatter will provide Json as well as `html` report. Multiple formatter is supported for cucumber v@0.8.0 or higher
