### PR TITLE
Added split to tags

### DIFF
--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -59,7 +59,9 @@ module.exports = function(grunt) {
                     commands.push('-t', element);
                 });
             } else {
-                commands.push('-t', options.tags);
+	        options.tags.split(',').forEach(function (element, index, array) {
+			commands.push('-t', element);
+        	});
             }
         }
 


### PR DESCRIPTION
I needed to submit multiple tags at the command line, and I couldn't figure out any way to make it an array. So, if the --tags value is a string, now it splits on comma and makes a -t for each element in the split