### PR TITLE
Not depending on non-json sources to generate html. removed saveJson option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,6 @@ module.exports = function(grunt) {
         formats: ['html', 'pretty'],
         templateDir: 'templates/bootstrap',
         output: 'test/report/features_report.html',
-        saveJson: true,
         debug: true,
         theme: 'bootstrap'
     };

--- a/README.md
+++ b/README.md
@@ -118,28 +118,20 @@ Available: `['pretty', 'progress', 'summary', 'html']`
 
 e.g. `formats: ['html', 'pretty']`
 
-Note: `html` formatter will provide Json as well as `html` report. Multiple formatter is supported for cucumber v@0.8.0 or higher
-
-#### options.saveJson
-Type: `Boolean`
-Default: `'false'`
-Available: `['true', 'false']`
-
-To keep or not the generated json file, applicable for options.format = html only.
-It will be saved as options.output + '.json'
+Note: `html` formatter will provide Json as well as `html` report. Multiple formatter is supported for cucumber v@0.8.0 or higher.
 
 #### options.executeParallel
 Type: `Boolean`
 Default: `'undefined'`
 Available: `['true', 'false']`
 
-A flag to enable Parallel execution. 
+A flag to enable Parallel execution.
 
 * For Cucumber version latest or greater than v0.8.0
 ```
   • You can run Cucumber Features and/or Scenarios Parallel
   • `--parallel scenarios` runs scenarios parallel
-  • By default or `--parallel features` runs features in parallel 
+  • By default or `--parallel features` runs features in parallel
 ```
 
 For more information visit [cucumber-parallel][8] module
@@ -199,7 +191,7 @@ options: {
      ....
 }
 ```
-It will record all the failed scenarios to `@rerun.txt`. 
+It will record all the failed scenarios to `@rerun.txt`.
 
 Take a look at `options.formats` to generate html report
 

--- a/lib/processHandler.js
+++ b/lib/processHandler.js
@@ -93,7 +93,7 @@ module.exports = function HandleUsingProcess(grunt, options, commands, callback)
                 if (fs.existsSync(options.output + '.json')) {
                     jsonOutput= JSON.stringify(jsonFile.readFileSync(jsonOutputFilePath));
                 } else {
-                    grunt.log.error('Unable to find cucumberjs json output file.');
+                    grunt.log.error('Unable to find cucumberjs json output file \'%s\'', jsonOutputFilePath);
                 }
             }
 

--- a/lib/processHandler.js
+++ b/lib/processHandler.js
@@ -10,9 +10,10 @@ var commondir = require('commondir');
 module.exports = function HandleUsingProcess(grunt, options, commands, callback) {
     var version = grunt.file.readJSON('./package.json').version;
     var projectPkg = grunt.file.readJSON('package.json');
+    var cucumberVersion;
 
     try {
-        var cucumberVersion = require('../../cucumber/package.json').version;
+        cucumberVersion = require('../../cucumber/package.json').version;
     }catch(e) {
         throw new Error('Cucumber.js is not installed. NOTE: You can install Cucumber by "npm i cucumber". ' +
             'For more information please visit "https://www.npmjs.com/package/cucumber"');
@@ -92,7 +93,7 @@ module.exports = function HandleUsingProcess(grunt, options, commands, callback)
                 if (fs.existsSync(options.output + '.json')) {
                     jsonOutput= JSON.stringify(jsonFile.readFileSync(jsonOutputFilePath));
                 } else {
-                    jsonOutput = Buffer.concat(buffer).toString();
+                    grunt.log.error('Unable to find cucumberjs json output file.');
                 }
             }
 
@@ -147,7 +148,7 @@ module.exports = function HandleUsingProcess(grunt, options, commands, callback)
                         step.embeddings.forEach(function (embedding) {
                             if (embedding.mime_type === "text/plain") {
                                 if (!step.text) {
-                                    step.text = Base64.decode(embedding.data)
+                                    step.text = Base64.decode(embedding.data);
                                 } else {
                                     step.text = step.text.concat('<br>' + Base64.decode(embedding.data));
                                 }
@@ -255,9 +256,6 @@ module.exports = function HandleUsingProcess(grunt, options, commands, callback)
         };
 
         suite = setStats(suite);
-        if (options.saveJson) {
-            grunt.file.write(options.output + '.json', JSON.stringify(featureOutput, null, '\t'));
-        }
         grunt.file.write(
             options.output,
             _.template(grunt.file.read(getPath('index.tmpl')))({

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -28,11 +28,7 @@ module.exports = function(grunt) {
         var applyLegacyFormatters = function() {
             if (options.format === 'html') {
                 options.isHtml = true;
-                if (options.executeParallel) {
-                    commands.push('-f', 'json:' + options.output + '.json');
-                } else {
-                    commands.push('-f', 'json');
-                }
+                commands.push('-f', 'json:' + options.output + '.json');
             } else {
                 commands.push('-f', options.format);
             }
@@ -77,7 +73,7 @@ module.exports = function(grunt) {
                     options.isHtml = true;
                     commands.push('-f', 'json:' + options.output + '.json');
                 } else {
-                    commands.push('-f', 'json:' + options.output + '.json');
+                    commands.push('-f', options.format);
                 }
             });
         } else if (options.format) {

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -14,7 +14,6 @@ module.exports = function(grunt) {
         var options = this.options({
             output: 'features_report.html',
             format: 'html',
-            saveJson: false,
             theme: 'foundation',
             templateDir: 'features/templates',
             tags: '',
@@ -78,7 +77,7 @@ module.exports = function(grunt) {
                     options.isHtml = true;
                     commands.push('-f', 'json:' + options.output + '.json');
                 } else {
-                    commands.push('-f', format);
+                    commands.push('-f', 'json:' + options.output + '.json');
                 }
             });
         } else if (options.format) {

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -73,7 +73,7 @@ module.exports = function(grunt) {
                     options.isHtml = true;
                     commands.push('-f', 'json:' + options.output + '.json');
                 } else {
-                    commands.push('-f', options.format);
+                    commands.push('-f', format);
                 }
             });
         } else if (options.format) {


### PR DESCRIPTION
As described here: https://github.com/mavdi/grunt-cucumberjs/issues/71.

Sorry for the cluttering, I had to pick up the changes from @gkushang from PR #75.
Feel free to cherry pick my last commits (https://github.com/mavdi/grunt-cucumberjs/pull/76/commits/3aff0963f999c866b59d3bb18c95c6afb92e034e and https://github.com/mavdi/grunt-cucumberjs/pull/76/commits/e22b0e097265d115c324009ec82ce1349d9cfea6)
