### PR TITLE
Fix rerun

### DIFF
--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -118,10 +118,10 @@ module.exports = function(grunt) {
             commands.push('--require', grunt.option('require'));
         }
 
-        if (grunt.option('rerun')) {
-            commands.push(grunt.option('rerun'));
-        } else if (grunt.option('features')) {
+        if (grunt.option('features')) {
             commands.push(grunt.option('features'));
+        } else if (grunt.option('rerun')) {
+            commands.push(grunt.option('rerun'));
         } else {
             this.files.forEach(function(f) {
                 f.src.forEach(function(filepath) {

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -114,15 +114,13 @@ module.exports = function(grunt) {
             }
         }
 
-        if (grunt.option('rerun')) {
-            commands.push(grunt.option('rerun'));
-        }
-
         if (grunt.option('require')) {
             commands.push('--require', grunt.option('require'));
         }
 
-        if (grunt.option('features')) {
+        if (grunt.option('rerun')) {
+            commands.push(grunt.option('rerun'));
+        } else if (grunt.option('features')) {
             commands.push(grunt.option('features'));
         } else {
             this.files.forEach(function(f) {


### PR DESCRIPTION
when grunt task runs `rerun.txt` then it should not pass path to the `feature`. Currently it runs rerun and then also run full regression suite. This PR fixes this issue.