### PR TITLE
Enable Rerun option for Parallel executions

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ Take a look at `options.formats` to generate html report
 
 * Run failed scenarios by passing `--rerun=path/to/@rerun.txt` grunt option
 
+N.B.: If `@rerun.txt` file does not exists or if file is empty, the grunt task will return success.
+
 
 #### options.compiler
 Type: `String`

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "chai": "^3.5.0",
     "cucumber-html-reporter": "^0.3.6",
     "cucumber-parallel": "^0.1.11",
-    "node-fs": "^0.1.7"
+    "node-fs": "^0.1.7",
+    "ramda": "^0.22.1"
   },
   "devDependencies": {
     "cucumber": "^1.3.1",

--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -119,17 +119,7 @@ module.exports = function(grunt) {
             commands.push('--require', grunt.option('require'));
         }
 
-        function returnIfEmpty(scenario) {
-            if (R.isEmpty(scenario)) {
-                grunt.log.warn('Rerun file "' + rerunFile + '" is empty. Exiting from task.');
-                return done();
-            }
-        }
-
-        function registerScenarios(scenario) {
-            returnIfEmpty(scenario);
-            commands.push(scenario);
-        }
+        var isScenarioEmpty = true;
 
         if (grunt.option('rerun')) {
 
@@ -142,11 +132,25 @@ module.exports = function(grunt) {
 
             var scenarios = fs.readFileSync(rerunFile, 'utf-8').split('\n');
 
-            returnIfEmpty(scenarios);
+            if (R.isEmpty(scenarios)) {
+                grunt.log.warn('Rerun file "' + rerunFile + '" is empty. Exiting from task: ' + scenario);
+                return done();
+            }
+
+            scenarios.forEach( function registerScenarios(scenario) {
+                if (isScenarioEmpty && R.isEmpty(scenario)) {
+                    grunt.log.warn('Rerun file "' + rerunFile + '" is empty. Exiting from task: ' + scenario);
+                    return done();
+                }
+
+                if (!R.isEmpty(scenario)) {
+                    commands.push(scenario);
+                    isScenarioEmpty = false;
+                }
+
+            });
 
             commands.push('--rerun', grunt.option('rerun'));
-
-            scenarios.forEach(registerScenarios);
 
         } else if (grunt.option('features')) {
             commands.push(grunt.option('features'));


### PR DESCRIPTION
Register `rerun` grunt options to cucumber params so that cucumber-parallel module can execute accordingly