### PR TITLE
Update cucumber-html-reporter to 4.0.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,16 @@
       "name": "Casey Goodhew",
       "email": "goodhewc@gmail.com",
       "url": "https://github.com/caseygoodhew"
+    },
+    {
+      "name": "John J. Barton",
+      "email": "johnjbarton@johnjbarton.com",
+      "url": "https://github.com/johnjbarton",
     }
   ],
   "dependencies": {
     "chai": "^4.1.2",
-    "cucumber-html-reporter": "^3.0.4",
+    "cucumber-html-reporter": "^4.0.3",
     "cucumber-parallel": "^2.0.3",
     "node-fs": "^0.1.7",
     "ramda": "^0.24.1"


### PR DESCRIPTION
Before 4.0.3, cucumber-html-reporter used 'open', a dep that is reported to have a security vulnerability:
 https://nodesecurity.io/advisories/663